### PR TITLE
Fix .gitignore line like '.tox/' not properly excluded in script

### DIFF
--- a/utils/from_mommy_to_bakery.py
+++ b/utils/from_mommy_to_bakery.py
@@ -72,7 +72,7 @@ def _sanitize_folder_or_file(folder_or_file):
 
 def check_files(dry_run):
     excluded_by_gitignore = [
-        _sanitize_folder_or_file(folder_or_file.strip())
+        _sanitize_folder_or_file(folder_or_file)
         for folder_or_file in open('.gitignore').readlines()
     ]
 


### PR DESCRIPTION
I was happy to see there is a script to help with the mommy -> baker migration, great idea!

However when I tried migrating the `from_mommy_to_bakery.py` stumbled over our `.gitignore` that included lines like:

```gitignore
# Unit test / coverage reports
htmlcov/
.tox/
nosetests.xml
coverage.xml
.cov/
```
The trailing slash on some of these resulted in the directory list not being filtered down as expected, thus `.tox` etc. were fully scanned. Removing the trailing slashes fixed that for me.

I've also taken the freedom to do a tiny change and avoid modifying the module global `exclude` and instead mark it as constant `EXCLUDE` and work on a copy within `check_files()`, I hope that wasn't too bold.