### PR TITLE
Use Travis Jobs for build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,85 @@
 language: python
+cache: pip
 dist: xenial
 branches:
   only:
   - master
-python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-env:
-  - DJANGO=django111
-  - DJANGO=django20
-  - DJANGO=django21
-  - DJANGO=django22
+jobs:
+  include:
+    - env: TOXENV=flake8
+      python: 3.7
+    - env: TOXENV=py35-django111-postgresql
+      python: 3.5
+    - env: TOXENV=py36-django111-postgresql
+      python: 3.6
+    - env: TOXENV=py37-django111-postgresql
+      python: 3.7
+    - env: TOXENV=py35-django111-sqlite
+      python: 3.5
+    - env: TOXENV=py36-django111-sqlite
+      python: 3.6
+    - env: TOXENV=py37-django111-sqlite
+      python: 3.7
+    - env: TOXENV=py35-django20-postgresql
+      python: 3.5
+    - env: TOXENV=py36-django20-postgresql
+      python: 3.6
+    - env: TOXENV=py37-django20-postgresql
+      python: 3.7
+    - env: TOXENV=py35-django20-sqlite
+      python: 3.5
+    - env: TOXENV=py36-django20-sqlite
+      python: 3.6
+    - env: TOXENV=py37-django20-sqlite
+      python: 3.7
+    - env: TOXENV=py35-django21-postgresql
+      python: 3.5
+    - env: TOXENV=py36-django21-postgresql
+      python: 3.6
+    - env: TOXENV=py37-django21-postgresql
+      python: 3.7
+    - env: TOXENV=py35-django21-sqlite
+      python: 3.5
+    - env: TOXENV=py36-django21-sqlite
+      python: 3.6
+    - env: TOXENV=py37-django21-sqlite
+      python: 3.7
+    - env: TOXENV=py35-django22-postgresql
+      python: 3.5
+    - env: TOXENV=py36-django22-postgresql
+      python: 3.6
+    - env: TOXENV=py37-django22-postgresql
+      python: 3.7
+    - env: TOXENV=py35-django22-sqlite
+      python: 3.5
+    - env: TOXENV=py36-django22-sqlite
+      python: 3.6
+    - env: TOXENV=py37-django22-sqlite
+      python: 3.7
+    - env: TOXENV=py35-django30-postgresql
+      python: 3.5
+    - env: TOXENV=py36-django30-postgresql
+      python: 3.6
+    - env: TOXENV=py37-django30-postgresql
+      python: 3.7
+    - env: TOXENV=py35-django30-sqlite
+      python: 3.5
+    - env: TOXENV=py36-django30-sqlite
+      python: 3.6
+    - env: TOXENV=py37-django30-sqlite
+      python: 3.7
+  allow_failures:
+    - env: TOXENV=py35-django30-postgresql
+      python: 3.5
+    - env: TOXENV=py36-django30-postgresql
+      python: 3.6
+    - env: TOXENV=py37-django30-postgresql
+      python: 3.7
+    - env: TOXENV=py35-django30-sqlite
+      python: 3.5
+    - env: TOXENV=py36-django30-sqlite
+      python: 3.6
+    - env: TOXENV=py37-django30-sqlite
 before_install:
   - sudo apt-get update && sudo apt-get build-dep python-imaging
   - sudo service postgresql restart
@@ -29,5 +97,4 @@ before_script:
   - psql template1 -c "create extension postgis;"
   - psql template1 -c "create extension citext;"
 script:
-  - TOX_TEST_PASSENV="TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH" tox -e py${TRAVIS_PYTHON_VERSION//[.]/}-$DJANGO-{postgresql}
-  - TOX_TEST_PASSENV="TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH" tox -e py${TRAVIS_PYTHON_VERSION//[.]/}-$DJANGO-{sqlite}
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,78 +8,30 @@ jobs:
   include:
     - env: TOXENV=flake8
       python: 3.7
-    - env: TOXENV=py35-django111-postgresql
+    - env: TOXENV=py35-django111-{postgresql,sqlite}
       python: 3.5
-    - env: TOXENV=py36-django111-postgresql
+    - env: TOXENV=py36-django111-{postgresql,sqlite}
       python: 3.6
-    - env: TOXENV=py37-django111-postgresql
+    - env: TOXENV=py37-django111-{postgresql,sqlite}
       python: 3.7
-    - env: TOXENV=py35-django111-sqlite
+    - env: TOXENV=py35-django20-{postgresql,sqlite}
       python: 3.5
-    - env: TOXENV=py36-django111-sqlite
+    - env: TOXENV=py36-django20-{postgresql,sqlite}
       python: 3.6
-    - env: TOXENV=py37-django111-sqlite
+    - env: TOXENV=py37-django20-{postgresql,sqlite}
       python: 3.7
-    - env: TOXENV=py35-django20-postgresql
+    - env: TOXENV=py35-django21-{postgresql,sqlite}
       python: 3.5
-    - env: TOXENV=py36-django20-postgresql
+    - env: TOXENV=py36-django21-{postgresql,sqlite}
       python: 3.6
-    - env: TOXENV=py37-django20-postgresql
+    - env: TOXENV=py37-django21-{postgresql,sqlite}
       python: 3.7
-    - env: TOXENV=py35-django20-sqlite
+    - env: TOXENV=py35-django22-{postgresql,sqlite}
       python: 3.5
-    - env: TOXENV=py36-django20-sqlite
+    - env: TOXENV=py36-django22-{postgresql,sqlite}
       python: 3.6
-    - env: TOXENV=py37-django20-sqlite
+    - env: TOXENV=py37-django22-{postgresql,sqlite}
       python: 3.7
-    - env: TOXENV=py35-django21-postgresql
-      python: 3.5
-    - env: TOXENV=py36-django21-postgresql
-      python: 3.6
-    - env: TOXENV=py37-django21-postgresql
-      python: 3.7
-    - env: TOXENV=py35-django21-sqlite
-      python: 3.5
-    - env: TOXENV=py36-django21-sqlite
-      python: 3.6
-    - env: TOXENV=py37-django21-sqlite
-      python: 3.7
-    - env: TOXENV=py35-django22-postgresql
-      python: 3.5
-    - env: TOXENV=py36-django22-postgresql
-      python: 3.6
-    - env: TOXENV=py37-django22-postgresql
-      python: 3.7
-    - env: TOXENV=py35-django22-sqlite
-      python: 3.5
-    - env: TOXENV=py36-django22-sqlite
-      python: 3.6
-    - env: TOXENV=py37-django22-sqlite
-      python: 3.7
-    - env: TOXENV=py35-django30-postgresql
-      python: 3.5
-    - env: TOXENV=py36-django30-postgresql
-      python: 3.6
-    - env: TOXENV=py37-django30-postgresql
-      python: 3.7
-    - env: TOXENV=py35-django30-sqlite
-      python: 3.5
-    - env: TOXENV=py36-django30-sqlite
-      python: 3.6
-    - env: TOXENV=py37-django30-sqlite
-      python: 3.7
-  allow_failures:
-    - env: TOXENV=py35-django30-postgresql
-      python: 3.5
-    - env: TOXENV=py36-django30-postgresql
-      python: 3.6
-    - env: TOXENV=py37-django30-postgresql
-      python: 3.7
-    - env: TOXENV=py35-django30-sqlite
-      python: 3.5
-    - env: TOXENV=py36-django30-sqlite
-      python: 3.6
-    - env: TOXENV=py37-django30-sqlite
 before_install:
   - sudo apt-get update && sudo apt-get build-dep python-imaging
   - sudo service postgresql restart

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py35-django{111,20,21,22}-{postgresql,sqlite}
-    py36-django{111,20,21,22}-{postgresql,sqlite}
-    py37-django{111,20,21,22}-{postgresql,sqlite}
+    py35-django{111,20,21,22,30}-{postgresql,sqlite}
+    py36-django{111,20,21,22,30}-{postgresql,sqlite}
+    py37-django{111,20,21,22,30}-{postgresql,sqlite}
     flake8
 
 [testenv]
@@ -23,6 +23,7 @@ deps =
     django20: Django==2.0
     django21: Django==2.1
     django22: Django>=2.2
+    django30: Django<=3.1
     postgresql: psycopg2-binary
 commands =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py35-django{111,20,21,22,30}-{postgresql,sqlite}
-    py36-django{111,20,21,22,30}-{postgresql,sqlite}
-    py37-django{111,20,21,22,30}-{postgresql,sqlite}
+    py35-django{111,20,21,22}-{postgresql,sqlite}
+    py36-django{111,20,21,22}-{postgresql,sqlite}
+    py37-django{111,20,21,22}-{postgresql,sqlite}
     flake8
 
 [testenv]
@@ -23,7 +23,6 @@ deps =
     django20: Django==2.0
     django21: Django==2.1
     django22: Django>=2.2
-    django30: Django<=3.1
     postgresql: psycopg2-binary
 commands =
     pytest


### PR DESCRIPTION
Our previous approach did not run flake8 job (which later will be extended with other linters and checkers).
This is an attempt to cover that issue.