### PR TITLE
Switch to tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,18 @@
 language: python
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
 cache: pip
 dist: xenial
 branches:
   only:
   - master
-jobs:
-  include:
-    - env: TOXENV=flake8
-      python: 3.7
-    - env: TOXENV=black
-      python: 3.7
-    - env: TOXENV=py35-django111-{postgresql,sqlite}
-      python: 3.5
-    - env: TOXENV=py36-django111-{postgresql,sqlite}
-      python: 3.6
-    - env: TOXENV=py37-django111-{postgresql,sqlite}
-      python: 3.7
-    - env: TOXENV=py35-django20-{postgresql,sqlite}
-      python: 3.5
-    - env: TOXENV=py36-django20-{postgresql,sqlite}
-      python: 3.6
-    - env: TOXENV=py37-django20-{postgresql,sqlite}
-      python: 3.7
-    - env: TOXENV=py35-django21-{postgresql,sqlite}
-      python: 3.5
-    - env: TOXENV=py36-django21-{postgresql,sqlite}
-      python: 3.6
-    - env: TOXENV=py37-django21-{postgresql,sqlite}
-      python: 3.7
-    - env: TOXENV=py35-django22-{postgresql,sqlite}
-      python: 3.5
-    - env: TOXENV=py36-django22-{postgresql,sqlite}
-      python: 3.6
-    - env: TOXENV=py37-django22-{postgresql,sqlite}
-      python: 3.7
 before_install:
   - sudo apt-get update && sudo apt-get build-dep python-imaging
   - sudo service postgresql restart
 install:
-  - pip install tox
+  - pip install tox-travis
 addons:
   postgresql: "9.6"
   apt:
@@ -51,4 +25,4 @@ before_script:
   - psql template1 -c "create extension postgis;"
   - psql template1 -c "create extension citext;"
 script:
-  - tox
+  - tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,16 @@ dist: xenial
 branches:
   only:
   - master
+before_install:
+  - sudo apt-get update && sudo apt-get build-dep python-imaging
+  - sudo service postgresql restart
 install:
   - pip install tox-travis
 addons:
-  postgresql: "11"
+  postgresql: "10"
   apt:
     packages:
-    - postgresql-11-postgis-2.5
+    - postgresql-10-postgis-2.5
 services:
   - postgresql
 before_script:
@@ -22,4 +25,4 @@ before_script:
   - psql template1 -c "create extension postgis;"
   - psql template1 -c "create extension citext;"
 script:
-  - tox
+  - tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_install:
 install:
   - pip install tox-travis
 addons:
-  postgresql: "9.6"
+  postgresql: "11"
   apt:
     packages:
-    - postgresql-9.6-postgis-2.4
+    - postgresql-11-postgis-2.5
 services:
   - postgresql
 before_script:
@@ -25,4 +25,4 @@ before_script:
   - psql template1 -c "create extension postgis;"
   - psql template1 -c "create extension citext;"
 script:
-  - tox -v
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ dist: xenial
 branches:
   only:
   - master
-before_install:
-  - sudo apt-get update && sudo apt-get build-dep python-imaging
-  - sudo service postgresql restart
 install:
   - pip install tox-travis
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_install:
 install:
   - pip install tox-travis
 addons:
-  postgresql: "10"
+  postgresql: "9.6"
   apt:
     packages:
-    - postgresql-10-postgis-2.5
+    - postgresql-9.6-postgis-2.4
 services:
   - postgresql
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,12 @@ envlist =
     flake8
     black
 
+[travis]
+python =
+    3.5: py35
+    3.6: py36,flake8,black
+    3.7: py37
+
 [testenv]
 setenv =
     PYTHONPATH={toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     django111: Django>=1.11,<1.12
     django20: Django==2.0
     django21: Django==2.1
-    django22: Django>=2.2
+    django22: Django==2.2
     postgresql: psycopg2-binary
 commands =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-    py35-django{111,20,21,22}-{postgresql,sqlite}
-    py36-django{111,20,21,22}-{postgresql,sqlite}
-    py37-django{111,20,21,22}-{postgresql,sqlite}
-    flake8
-    black
+;    py{35,36,37}-django{111,20,21,22}-{postgresql,sqlite}
+    py36-django22-postgresql
+;    flake8
+;    black
 
 [travis]
 python =
@@ -18,10 +17,6 @@ setenv =
     postgresql: TEST_DB=postgis
     sqlite: TEST_DB=sqlite
     sqlite: USE_TZ=True
-basepython =
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
 deps =
     pillow
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-;    py{35,36,37}-django{111,20,21,22}-{postgresql,sqlite}
-    py36-django22-postgresql
-;    flake8
-;    black
+    py{35,36,37}-django{111,20,21,22}-{postgresql,sqlite}
+    flake8
+    black
 
 [travis]
 python =


### PR DESCRIPTION
This PR adds official Travis package, called `tox-travis` (https://tox-travis.readthedocs.io/en/stable/) to simplify test suite.

Previously we defined complicated matrix in travis config to run all possible version and service variations we have. Now this package handles all that, we only need to specify which python versions to run against. This looks much cleaner and simpler to maintain.

Also, now it uses **3 jobs instead of 14**, which reduces running time from **~11 minutes down to ~4 minutes**.
Total run time reduced from **~27 minutes to ~11 minutes**.

Linting tasks are running under python 3.6 environment since version does not really matter here (instead of having expensive separate job).

And I need to mention a small positive bug fix that I accidentaly made here. PostgreSQL tests were not running after switching to Travis matrix (shame on me):
https://travis-ci.com/model-bakers/model_bakery/jobs/262622958

Now they do run properly. :)