### PR TITLE
Changes list comprehension to for loop

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -64,14 +64,13 @@ def make(
         raise InvalidQuantityException
 
     if _quantity:
-        return [
+        for _ in range(_quantity):
             baker.make(
                 _save_kwargs=_save_kwargs,
                 _refresh_after_create=_refresh_after_create,
                 **attrs
             )
-            for _ in range(_quantity)
-        ]
+            return True
     return baker.make(
         _save_kwargs=_save_kwargs, _refresh_after_create=_refresh_after_create, **attrs
     )


### PR DESCRIPTION
List comprehensions should only be used in case of a function being applied to list items. In this case, the list comprehension was used to loop over and create new model objects.