### PR TITLE
Add Django 3.0 and Python 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
   only:
   - master
 before_install:
-  - sudo apt-get update && sudo apt-get build-dep python-imaging
+  - sudo apt-get update && sudo apt-get build-dep python-imaging libgdal-dev
   - sudo service postgresql restart
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ before_install:
 install:
   - pip install tox-travis
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
   apt:
     packages:
-    - postgresql-9.6-postgis-2.4
+    - postgresql-10-postgis-2.5
 services:
   - postgresql
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 cache: pip
 dist: xenial
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
   only:
   - master
 before_install:
-  - sudo apt-get update && sudo apt-get install libgdal-dev
+#  - sudo apt-get update && sudo apt-get install libgdal-dev
   - sudo service postgresql restart
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 #  - "3.7"
 #  - "3.8"
 cache: pip
-dist: xenial
+dist: bionic
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: python
 python:
-#  - "3.5"
+  - "3.5"
   - "3.6"
-#  - "3.7"
-#  - "3.8"
+  - "3.7"
+  - "3.8"
 cache: pip
 dist: bionic
 branches:
   only:
   - master
-before_install:
-#  - sudo apt-get update && sudo apt-get install libgdal-dev
-  - sudo service postgresql restart
 install:
   - pip install tox-travis
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 python:
-  - "3.5"
+#  - "3.5"
   - "3.6"
-  - "3.7"
-  - "3.8"
+#  - "3.7"
+#  - "3.8"
 cache: pip
 dist: xenial
 branches:
   only:
   - master
 before_install:
-  - sudo apt-get update && sudo apt-get build-dep python-imaging libgdal-dev
+  - sudo apt-get update && sudo apt-get install libgdal-dev
   - sudo service postgresql restart
 install:
   - pip install tox-travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add Django 3.0 and Python 3.8 to CI (https://github.com/model-bakers/model_bakery/pull/48/)
 
 ### Removed
-- Python 3.5 support ((https://github.com/model-bakers/model_bakery/pull/48/))
 
 ## [1.0.2](https://pypi.org/project/model-bakery/1.0.2/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `model_bakery` will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased](https://github.com/model-bakers/model_bakery/tree/master)
+
+### Added
+
+### Changed
+- Improve code comments (https://github.com/model-bakers/model_bakery/pull/31)
+- Switch to tox-travis (https://github.com/model-bakers/model_bakery/pull/43)
+- Add black job (https://github.com/model-bakers/model_bakery/pull/42)
+- README.md instead of rst (https://github.com/model-bakers/model_bakery/pull/44)
+- Add Django 3.0 and Python 3.8 to CI (https://github.com/model-bakers/model_bakery/pull/48/)
+
+### Removed
+- Python 3.5 support ((https://github.com/model-bakers/model_bakery/pull/48/))
+
 ## [1.0.2](https://pypi.org/project/model-bakery/1.0.2/)
 
 ### Added

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ As an open source project, Model Bakery welcomes contributions of many forms. Ex
 Compatibility
 =============
 
-model_bakery supports Django >= 1.11 and Python >= 3.5
+model_bakery supports Django >= 1.11 and Python >= 3.6
 
 Install
 =======

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ As an open source project, Model Bakery welcomes contributions of many forms. Ex
 Compatibility
 =============
 
-model_bakery supports Django >= 1.11 and Python >= 3.6
+model_bakery supports Django >= 1.11
 
 Install
 =======

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     django20: Django==2.0
     django21: Django==2.1
     django22: Django==2.2
-    django30: Django==3.0
+    django30: Django>=3.0a1,<3.1
     postgresql: psycopg2-binary
 commands =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-;    py{35,36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
-    py36-django30-postgresql
-;    flake8
-;    black
+    py{35,36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
+    flake8
+    black
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py{35,36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
+    py{36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
     flake8
     black
 
 [travis]
 python =
-    3.5: py35
     3.6: py36,flake8,black
     3.7: py37
     3.8: py38

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37}-django{111,20,21,22}-{postgresql,sqlite}
+    py{35,36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
     flake8
     black
 
@@ -9,6 +9,7 @@ python =
     3.5: py35
     3.6: py36,flake8,black
     3.7: py37
+    3.8: py38
 
 [testenv]
 setenv =
@@ -24,6 +25,7 @@ deps =
     django20: Django==2.0
     django21: Django==2.1
     django22: Django==2.2
+    django30: Django==3.0
     postgresql: psycopg2-binary
 commands =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-    py{35,36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
-    flake8
-    black
+;    py{35,36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
+    py36-django30-postgresql
+;    flake8
+;    black
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 envlist =
+    py35-django{111,20,21,22}-{postgresql,sqlite}
     py{36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
     flake8
     black
 
 [travis]
 python =
+    3.5: py35
     3.6: py36,flake8,black
     3.7: py37
     3.8: py38


### PR DESCRIPTION
Fix #45

This PR:
- Adds Django 3.0 and Python 3.8 to Travis CI
- Updates Postgres version on Travis (PG 10, postgis 2.5)
- Switches Travis CI from xenial to bionic (Ubuntu 18.04)
- Removes obsolete `before_install` commands
- Removes Python 3.5 as Django 3.0 does not support it (I don't think we need to support this version)
- Updates changelog with all changes since 1.0.2