### PR TITLE
Fix error when adding custom fields generators to bakery via settings file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add black job (https://github.com/model-bakers/model_bakery/pull/42)
 - README.md instead of rst (https://github.com/model-bakers/model_bakery/pull/44)
 - Add Django 3.0 and Python 3.8 to CI (https://github.com/model-bakers/model_bakery/pull/48/)
+- Fixes bug when registerin custom field's generator via `settings.py`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add black job (https://github.com/model-bakers/model_bakery/pull/42)
 - README.md instead of rst (https://github.com/model-bakers/model_bakery/pull/44)
 - Add Django 3.0 and Python 3.8 to CI (https://github.com/model-bakers/model_bakery/pull/48/)
-- Fixes bug when registerin custom field's generator via `settings.py`
+- Fixes bug when registering custom fields generator via `settings.py`
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -489,13 +489,15 @@ class Baker(object):
         `attr_mapping` and `type_mapping` can be defined easily overwriting the
         model.
         """
+        is_content_type_fk = isinstance(field, ForeignKey) and issubclass(
+            self._remote_field(field).model, contenttypes.models.ContentType
+        )
+
         if field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]
         elif getattr(field, "choices"):
             generator = random_gen.gen_from_choices(field.choices)
-        elif isinstance(field, ForeignKey) and issubclass(
-            self._remote_field(field).model, contenttypes.models.ContentType
-        ):
+        elif is_content_type_fk:
             generator = self.type_mapping[contenttypes.models.ContentType]
         elif generators.get(field.__class__):
             generator = generators.get(field.__class__)

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -1,9 +1,8 @@
 from os.path import dirname, join
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
+from django.contrib import contenttypes
 from django.apps import apps
-from django.contrib.contenttypes.fields import GenericRelation
 
 from django.db.models.base import ModelBase
 from django.db.models import (
@@ -404,6 +403,8 @@ class Baker(object):
 
     def _skip_field(self, field):
         # check for fill optional argument
+        from django.contrib.contenttypes.fields import GenericRelation
+
         if isinstance(self.fill_in_optional, bool):
             field.fill_optional = self.fill_in_optional
         else:
@@ -493,9 +494,9 @@ class Baker(object):
         elif getattr(field, "choices"):
             generator = random_gen.gen_from_choices(field.choices)
         elif isinstance(field, ForeignKey) and issubclass(
-            self._remote_field(field).model, ContentType
+            self._remote_field(field).model, contenttypes.models.ContentType
         ):
-            generator = self.type_mapping[ContentType]
+            generator = self.type_mapping[contenttypes.models.ContentType]
         elif generators.get(field.__class__):
             generator = generators.get(field.__class__)
         elif field.__class__ in self.type_mapping:

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -402,9 +402,9 @@ class Baker(object):
         ]
 
     def _skip_field(self, field):
-        # check for fill optional argument
         from django.contrib.contenttypes.fields import GenericRelation
 
+        # check for fill optional argument
         if isinstance(self.fill_in_optional, bool):
             field.fill_optional = self.fill_in_optional
         else:

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -29,7 +29,6 @@ from django.db.models import (
 )
 
 from . import random_gen
-from .gis import default_gis_mapping
 from .utils import import_from_str
 
 try:
@@ -103,13 +102,16 @@ if CITextField:
     default_mapping[CITextField] = random_gen.gen_text
 
 # Add GIS fields
-default_mapping.update(default_gis_mapping)
 
 
 def get_type_mapping():
     from django.contrib.contenttypes.models import ContentType
+    from .gis import default_gis_mapping
+
     mapping = default_mapping.copy()
     mapping[ContentType] = random_gen.gen_content_type
+    default_mapping.update(default_gis_mapping)
+
     return mapping.copy()
 
 

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -1,4 +1,3 @@
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import (
     BigIntegerField,
     BinaryField,
@@ -88,7 +87,6 @@ default_mapping = {
     FileField: random_gen.gen_file_field,
     ImageField: random_gen.gen_image_field,
     DurationField: random_gen.gen_interval,
-    ContentType: random_gen.gen_content_type,
 }
 
 if ArrayField:
@@ -109,7 +107,9 @@ default_mapping.update(default_gis_mapping)
 
 
 def get_type_mapping():
+    from django.contrib.contenttypes.models import ContentType
     mapping = default_mapping.copy()
+    mapping[ContentType] = random_gen.gen_content_type
     return mapping.copy()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ def pytest_configure():
     from model_bakery import baker
 
     def gen_same_text():
-        return 'always the same text'
+        return "always the same text"
+
     baker.generators.add("tests.generic.fields.CustomFieldViaSettings", gen_same_text)
 
     django.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def pytest_configure():
         ] + installed_apps
     else:
         raise NotImplementedError("Tests for % are not supported", test_db)
+
     settings.configure(
         DATABASES={"default": {"ENGINE": db_engine, "NAME": db_name}},
         INSTALLED_APPS=installed_apps,
@@ -37,4 +38,9 @@ def pytest_configure():
         MIDDLEWARE=(),
         USE_TZ=os.environ.get("USE_TZ", False),
     )
+
+    from model_bakery import baker
+
+    baker.generators.add("tests.generic.fields.CustomFieldWithGenerator", None)
+
     django.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,8 @@ def pytest_configure():
 
     from model_bakery import baker
 
-    baker.generators.add("tests.generic.fields.CustomFieldWithGenerator", None)
+    def gen_same_text():
+        return 'always the same text'
+    baker.generators.add("tests.generic.fields.CustomFieldViaSettings", gen_same_text)
 
     django.setup()

--- a/tests/generic/fields.py
+++ b/tests/generic/fields.py
@@ -9,6 +9,10 @@ class CustomFieldWithoutGenerator(models.TextField):
     pass
 
 
+class CustomFieldViaSettings(models.TextField):
+    pass
+
+
 class FakeListField(models.TextField):
     def to_python(self, value):
         return value.split()

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -16,6 +16,7 @@ from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKe
 from .fields import (
     CustomFieldWithGenerator,
     CustomFieldWithoutGenerator,
+    CustomFieldViaSettings,
     FakeListField,
     CustomForeignKey,
 )
@@ -289,6 +290,10 @@ class CustomFieldWithGeneratorModel(models.Model):
 
 class CustomFieldWithoutGeneratorModel(models.Model):
     custom_value = CustomFieldWithoutGenerator()
+
+
+class CustomFieldViaSettingsModel(models.Model):
+    custom_value = CustomFieldViaSettings()
 
 
 class CustomForeignKeyWithGeneratorModel(models.Model):

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -334,6 +334,10 @@ class TestFillingCustomFields:
 
         assert "Some value" == person.name
 
+    def test_ensure_adding_generators_via_settings_works(self):
+        obj = baker.make(models.CustomFieldViaSettingsModel)
+        assert "always the same text" == obj.custom_value
+
 
 @pytest.mark.django_db
 class TestFillingAutoFields:


### PR DESCRIPTION
Fixes #18 

The many comments on #18 describes why this work was required, but the short summary is that [the instruction in the docs](https://model-bakery.readthedocs.io/en/latest/how_bakery_behaves.html#custom-fields) to set generators for custom fields via `settings.py` wasn't working. Django raises the exception `AppRegistryNotReady` if the code tries to import anything related to the DB before properly creating the models.

Model bakery wasn't respecting this rule because it was importing the `ContentType` model and a few `django.contrib.gis` models too. This PR fixes this by replacing direct imports by module's imports and by moving others imports to be done during the execution time.