### PR TITLE
Increase default randomness for integer generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add black job (https://github.com/model-bakers/model_bakery/pull/42)
 - README.md instead of rst (https://github.com/model-bakers/model_bakery/pull/44)
 - Add Django 3.0 and Python 3.8 to CI (https://github.com/model-bakers/model_bakery/pull/48/)
+- The different IntegerField types now will generate values on their min/max range (https://github.com/model-bakers/model_bakery/pull/59)
 
 ### Removed
 

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -35,6 +35,18 @@ from .gis import default_gis_mapping
 from .utils import import_from_str
 
 try:
+    from django.db.models import AutoField, BigAutoField, SmallAutoField
+except ImportError:
+    AutoField = None
+    BigAutoField = None
+    SmallAutoField = None
+
+try:
+    from django.db.models import PositiveBigIntegerField
+except ImportError:
+    PositiveBigIntegerField = None
+
+try:
     from django.contrib.postgres.fields import ArrayField
 except ImportError:
     ArrayField = None
@@ -113,6 +125,17 @@ if CIEmailField:
     default_mapping[CIEmailField] = random_gen.gen_email
 if CITextField:
     default_mapping[CITextField] = random_gen.gen_text
+if AutoField:
+    default_mapping[AutoField] = _make_integer_gen_by_range(AutoField)
+if BigAutoField:
+    default_mapping[BigAutoField] = _make_integer_gen_by_range(BigAutoField)
+if SmallAutoField:
+    default_mapping[SmallAutoField] = _make_integer_gen_by_range(SmallAutoField)
+if PositiveBigIntegerField:
+    default_mapping[PositiveBigIntegerField] = _make_integer_gen_by_range(
+        PositiveBigIntegerField
+    )
+
 
 # Add GIS fields
 default_mapping.update(default_gis_mapping)

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models import (
     BigIntegerField,
     BinaryField,
@@ -60,17 +61,27 @@ except ImportError:
     CITextField = None
 
 
+def _make_integer_gen_by_range(field_type):
+    min_int, max_int = (
+        BaseDatabaseOperations.integer_field_ranges[field_type.__name__]
+    )
+
+    def gen_integer():
+        return random_gen.gen_integer(min_int=min_int, max_int=max_int)
+    return gen_integer
+
+
 default_mapping = {
     ForeignKey: random_gen.gen_related,
     OneToOneField: random_gen.gen_related,
     ManyToManyField: random_gen.gen_m2m,
     BooleanField: random_gen.gen_boolean,
     NullBooleanField: random_gen.gen_boolean,
-    IntegerField: random_gen.gen_integer,
-    BigIntegerField: random_gen.gen_integer,
-    SmallIntegerField: random_gen.gen_integer,
-    PositiveIntegerField: lambda: random_gen.gen_integer(min_int=0),
-    PositiveSmallIntegerField: lambda: random_gen.gen_integer(min_int=0),
+    IntegerField: _make_integer_gen_by_range(IntegerField),
+    BigIntegerField: _make_integer_gen_by_range(BigIntegerField),
+    SmallIntegerField: _make_integer_gen_by_range(SmallIntegerField),
+    PositiveIntegerField: _make_integer_gen_by_range(PositiveIntegerField),
+    PositiveSmallIntegerField: _make_integer_gen_by_range(PositiveSmallIntegerField),
     FloatField: random_gen.gen_float,
     DecimalField: random_gen.gen_decimal,
     BinaryField: random_gen.gen_byte_string,

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -62,12 +62,11 @@ except ImportError:
 
 
 def _make_integer_gen_by_range(field_type):
-    min_int, max_int = (
-        BaseDatabaseOperations.integer_field_ranges[field_type.__name__]
-    )
+    min_int, max_int = BaseDatabaseOperations.integer_field_ranges[field_type.__name__]
 
     def gen_integer():
         return random_gen.gen_integer(min_int=min_int, max_int=max_int)
+
     return gen_integer
 
 

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -21,7 +21,7 @@ from model_bakery.timezone import now
 MAX_LENGTH = 300
 # Using sys.maxint here breaks a bunch of tests when running against a
 # Postgres database.
-MAX_INT = 10000
+MAX_INT = 100000000000
 
 
 def get_content_file(content, name):


### PR DESCRIPTION
I think 10000 is just too low. 
We have been having flakyness in our tests with UNIQUE constraints on Integer columns because of conflicting values we this generator.