### PR TITLE
Fixes PostGIS model registration

### DIFF
--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -143,7 +143,7 @@ def get_type_mapping():
 
     mapping = default_mapping.copy()
     mapping[ContentType] = random_gen.gen_content_type
-    default_mapping.update(default_gis_mapping)
+    mapping.update(default_gis_mapping)
 
     return mapping.copy()
 


### PR DESCRIPTION
The result of `generators.get_type_mapping()` is being used when registering types in `baker.init_type_mapping`, but the return value of `get_type_mapping` is being set to the copied value of the mappings _before_ postgis models have been added.  This leads model baker to believe that the PostGis models are invalid, when in fact, they are valid.

Given this model in `myapp/models.py`...
```
from django.contrib.gis.db import models as gis_models
from django.db import models

class MyModel(models.Model):
    point = gis_models.PointField(srid=4326)
```

The code below errors when executed in the Django shell:
```
from model_bakery import baker
instance = baker.make(MyModel)
```
with the following error: `TypeError: <class 'django.contrib.gis.db.models.fields.PointField'> is not supported by baker.`

I've tested this change locally, and it works, but I'm not sure why this is not being picked up in the tests on TravisCI