### PR TITLE
docs: Fix simple typo, specifing -> specifying

### DIFF
--- a/docs/source/how_bakery_behaves.rst
+++ b/docs/source/how_bakery_behaves.rst
@@ -58,7 +58,7 @@ Custom fields
 -------------
 
 Model Bakery allows you to define generators methods for your custom fields or overrides its default generators.
-This can be achieved by specifing the field and generator function for the ``generators.add`` function.
+This can be achieved by specifying the field and generator function for the ``generators.add`` function.
 Both can be the real python objects imported in settings or just specified as import path string.
 
 Examples:


### PR DESCRIPTION
There is a small typo in docs/source/how_bakery_behaves.rst.

Should read `specifying` rather than `specifing`.

