### PR TITLE
Enable seq to be imported from baker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Enable `seq` to be imported from `baker` [PR #76](https://github.com/model-bakers/model_bakery/pull/76)
 
 ### Removed
 

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -225,20 +225,18 @@ Sometimes, you have a field with an unique value and using ``make`` can cause ra
 
 This will append a counter to strings to avoid uniqueness problems and it will sum the counter with numerical values.
 
-Sequences and iterables can be used not only for recipes, but with ``baker.make`` as well:
+Sequences and iterables can be used not only for recipes, but with ``baker`` as well:
 
 .. code-block:: python
 
 
-    # it can be imported directly from model_bakery
-    >>> from model_bakery import seq
     >>> from model_bakery import baker
 
-    >>> customer = baker.make('Customer', name=seq('Joe'))
+    >>> customer = baker.make('Customer', name=baker.seq('Joe'))
     >>> customer.name
     'Joe1'
 
-    >>> customers = baker.make('Customer', name=seq('Chad'), _quantity=3)
+    >>> customers = baker.make('Customer', name=baker.seq('Chad'), _quantity=3)
     >>> for customer in customers:
     ...     print(customer.name)
     'Chad1'

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -30,6 +30,9 @@ from .exceptions import (
 )
 from .utils import import_from_str
 
+# Enable seq to be imported from baker
+from .utils import seq  # NoQA
+
 recipes = None
 
 # FIXME: use pkg_resource

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -20,6 +20,14 @@ from tests.generic import models
 from tests.generic.forms import DummyGenericIPAddressFieldForm
 
 
+def test_import_seq_from_baker():
+    """Test import seq method from baker module."""
+    try:
+        from model_bakery.baker import seq  # NoQA
+    except ImportError:
+        pytest.fail("{} raised".format(ImportError.__name__))
+
+
 class TestsModelFinder:
     def test_unicode_regression(self):
         obj = baker.prepare("generic.Person")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -33,17 +33,16 @@ recipe_attrs = {
 person_recipe = Recipe(Person, **recipe_attrs)
 
 
+def test_import_seq_from_recipe():
+    """Test import seq method from recipe module."""
+    try:
+        from model_bakery.recipe import seq  # NoQA
+    except ImportError:
+        pytest.fail("{} raised".format(ImportError.__name__))
+
+
 @pytest.mark.django_db
 class TestDefiningRecipes:
-    def test_import_seq_from_baker(self):
-        """
-            Import seq method directly from baker module
-        """
-        try:
-            from model_bakery import seq  # NoQA
-        except ImportError:
-            self.fail("{} raised".format(ImportError.__name__))
-
     def test_flat_model_make_recipe_with_the_correct_attributes(self):
         """
           A 'flat model' means a model without associations, like
@@ -165,7 +164,7 @@ class TestDefiningRecipes:
         try:
             p.make(_quantity=5)
         except AttributeError as e:
-            self.fail("%s" % e)
+            pytest.fail("%s" % e)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Enable the seq() function to be imported from the baker module like
it is in the recipe module so that it can be used as baker.seq() if
preferred or to avoid namespace issues.

The current import can be left in place for backwards compatibility
or to continue importing seq as before.

Closes #75