### PR TITLE
Improve contributing instructions and utilitaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+## How to Contribute
+
+This page list all the steps you need to follow to set up `model_bakery` and be able to code it. Here they are:
+
+1. [Fork this repo](https://github.com/model-bakers/model_bakery/fork) and clone it to your computer:
+
+```
+git clone git@github.com:YOUR_USER/model_bakery.git
+```
+
+2. Install the dev dependencies:
+
+```
+pip install -r dev_requirements.txt
+```
+
+3. Change the code and run your tests with:
+
+```
+make test
+```
+
+4. We use [pre-commit](https://pre-commit.com/) to ensure a unique code formatting for the project. But, if you ran into any CI issues with that, make sure your code changes respect it:
+
+```
+make lint
+```
+
+If you don't follow the step 4, your PR may fail due to `black`, `isort` or flake8` warnings.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ release:
 	@twine upload dist/*
 
 lint:
+	@isort model_bakery
 	@black model_bakery
 	@flake8 model_bakery
 

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,8 @@ release:
 	@python setup.py sdist bdist_wheel
 	@twine upload dist/*
 
+lint:
+	@black model_bakery
+	@flake8 model_bakery
+
 .PHONY: test release

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ $ pip install -r dev_requirements.txt
 $ make test
 ```
 
-4. Before opening your PR, make sure your code changes respect the project's format with:
+4. We use [pre-commit](https://pre-commit.com/) to ensure a unique code formatting for the project. But, if you ran into any CI issues with that, make sure your code changes respect it:
 
 ```
 $ make lint
 ```
 
-If you don't follow the step 4, your PR may fail due to `black` or `flake8` warnings.
+If you don't follow the step 4, your PR may fail due to `black`, `isort` or flake8` warnings.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ class TestCustomerModel(TestCase):
 
 Check out [documentation](<http://model-bakery.readthedocs.org/>) for more complete examples.
 
+## Contributing
+
+1. Fork this repo and clone it to your computer:
+
+```
+$ git clone git@github.com:YOUR_USER/model_bakery.git
+```
+
+2. Install the dev dependencies:
+
+```
+$ pip install -r dev_requirements.txt
+```
+
+3. Change the code and run your tests with:
+
+```
+$ make test
+```
+
+4. Before opening your PR, make sure your code changes respect the project's format with:
+
+```
+$ make lint
+```
+
+If you don't follow the step 4, your PR may fail due to `black` or `flake8` warnings.
+
 ## Maintainers
 
   - [Ana Paula Gomes](https://github.com/anapaulagomes/)

--- a/README.md
+++ b/README.md
@@ -66,25 +66,25 @@ Check out [documentation](<http://model-bakery.readthedocs.org/>) for more compl
 1. Fork this repo and clone it to your computer:
 
 ```
-$ git clone git@github.com:YOUR_USER/model_bakery.git
+git clone git@github.com:YOUR_USER/model_bakery.git
 ```
 
 2. Install the dev dependencies:
 
 ```
-$ pip install -r dev_requirements.txt
+pip install -r dev_requirements.txt
 ```
 
 3. Change the code and run your tests with:
 
 ```
-$ make test
+make test
 ```
 
 4. We use [pre-commit](https://pre-commit.com/) to ensure a unique code formatting for the project. But, if you ran into any CI issues with that, make sure your code changes respect it:
 
 ```
-$ make lint
+make lint
 ```
 
 If you don't follow the step 4, your PR may fail due to `black`, `isort` or flake8` warnings.

--- a/README.md
+++ b/README.md
@@ -63,31 +63,7 @@ Check out [documentation](<http://model-bakery.readthedocs.org/>) for more compl
 
 ## Contributing
 
-1. [Fork this repo](https://github.com/model-bakers/model_bakery/fork) and clone it to your computer:
-
-```
-git clone git@github.com:YOUR_USER/model_bakery.git
-```
-
-2. Install the dev dependencies:
-
-```
-pip install -r dev_requirements.txt
-```
-
-3. Change the code and run your tests with:
-
-```
-make test
-```
-
-4. We use [pre-commit](https://pre-commit.com/) to ensure a unique code formatting for the project. But, if you ran into any CI issues with that, make sure your code changes respect it:
-
-```
-make lint
-```
-
-If you don't follow the step 4, your PR may fail due to `black`, `isort` or flake8` warnings.
+Detailed info [here](https://github.com/model-bakers/model_bakery/blob/master/CONTRIBUTING.md).
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Check out [documentation](<http://model-bakery.readthedocs.org/>) for more compl
 
 ## Contributing
 
-1. Fork this repo and clone it to your computer:
+1. [Fork this repo](https://github.com/model-bakers/model_bakery/fork) and clone it to your computer:
 
 ```
 git clone git@github.com:YOUR_USER/model_bakery.git

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,25 +35,7 @@ Install it with ``pip``
 Contributing
 ============
 
-1. Prepare a virtual environment.
-
-.. code-block:: console
-
-    $ pip install virtualenvwrapper
-    $ mkvirtualenv model_bakery
-
-2. Install the requirements.
-
-.. code-block:: console
-
-    $ pip install -r dev_requirements.txt
-
-3. Run the tests.
-
-.. code-block:: console
-
-    $ make test
-
+Take a look in our `Github repo <https://github.com/model-bakers/model_bakery#contributing>`_ for more instructions on how to set up your local environment to help Model Bakery to grow.
 
 Doubts? Loved it? Hated it? Suggestions?
 ========================================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,16 +8,6 @@ With a simple and powerful API you can create many objects with a single line of
 Model Bakery is a rename of the legacy `model_mommy's project <https://pypi.org/project/model_mommy/>`_. This is because the project's creator and maintainers decided to not reinforce gender stereotypes for women in technology. You can read more about this subject `here <https://witi.com/articles/1017/How-Gender-Stereotypes-are-Still-Affecting-Women-in-Tech/>`_.
 
 
-Contributing to Model Bakery
-============================
-
-As an open source project, Model Bakery welcomes contributions of many forms. Examples of contributions include:
-
-* Code Patches
-* Documentation improvements
-* Bug reports
-
-
 Compatibility
 =============
 
@@ -32,10 +22,17 @@ Install it with ``pip``
 
     $ pip install model_bakery
 
-Contributing
-============
 
-Take a look in our `Github repo <https://github.com/model-bakers/model_bakery#contributing>`_ for more instructions on how to set up your local environment to help Model Bakery to grow.
+Contributing to Model Bakery
+============================
+
+As an open source project, Model Bakery welcomes contributions of many forms. Examples of contributions include:
+
+* Code Patches
+* Documentation improvements
+* Bug reports
+
+Take a look in our `Github repo <https://github.com/model-bakers/model_bakery/blob/master/CONTRIBUTING.md>`_ for more instructions on how to set up your local environment to help Model Bakery to grow.
 
 Doubts? Loved it? Hated it? Suggestions?
 ========================================

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -191,10 +191,10 @@ def gen_byte_string(max_length=16):
     return bytes(generator)
 
 
-def gen_interval(interval_key="milliseconds"):
+def gen_interval(interval_key="milliseconds", offset=0):
     from datetime import timedelta
 
-    interval = gen_integer()
+    interval = gen_integer() + offset
     kwargs = {interval_key: interval}
     return timedelta(**kwargs)
 
@@ -326,7 +326,7 @@ def gen_date_range():
     from psycopg2.extras import DateRange
 
     base_date = gen_date()
-    interval = gen_interval()
+    interval = gen_interval(offset=24 * 60 * 60 * 1000)  # force at least 1 day interval
     args = sorted([base_date - interval, base_date + interval])
     return DateRange(*args)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,14 +14,17 @@ def pytest_configure():
         "tests.ambiguous2",
     ]
 
+    using_postgres_flag = False
     if test_db == "sqlite":
         db_engine = "django.db.backends.sqlite3"
         db_name = ":memory:"
     elif test_db == "postgresql":
+        using_postgres_flag = True
         db_engine = "django.db.backends.postgresql_psycopg2"
         db_name = "postgres"
         installed_apps = ["django.contrib.postgres"] + installed_apps
     elif test_db == "postgis":
+        using_postgres_flag = True
         db_engine = "django.contrib.gis.db.backends.postgis"
         db_name = "postgres"
         installed_apps = [
@@ -38,6 +41,7 @@ def pytest_configure():
         SITE_ID=1,
         MIDDLEWARE=(),
         USE_TZ=os.environ.get("USE_TZ", False),
+        USING_POSTGRES=using_postgres_flag,
     )
 
     from model_bakery import baker

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -21,8 +21,6 @@ from .fields import (
     FakeListField,
 )
 
-USING_POSTGRES = bool("sqlite" not in settings.DATABASES["default"]["ENGINE"])
-
 # check whether or not PIL is installed
 try:
     from PIL import ImageFile as PilImageFile  # NoQA
@@ -105,7 +103,7 @@ class Person(models.Model):
             DateTimeRangeField,
         )
 
-        if USING_POSTGRES:
+        if settings.USING_POSTGRES:
             acquaintances = ArrayField(models.IntegerField())
             data = JSONField()
             hstore_data = HStoreField()
@@ -124,7 +122,7 @@ class Person(models.Model):
     try:
         from django.contrib.postgres.fields.ranges import DecimalRangeField
 
-        if USING_POSTGRES:
+        if settings.USING_POSTGRES:
             decimal_range = DecimalRangeField()
     except ImportError:
         # Django version lower than 2.2

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -9,6 +9,7 @@ from tempfile import gettempdir
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import FileSystemStorage
+from django.conf import settings
 from model_bakery.gis import BAKER_GIS
 from model_bakery.timezone import smart_datetime as datetime
 
@@ -19,6 +20,8 @@ from .fields import (
     CustomForeignKey,
     FakeListField,
 )
+
+USING_POSTGRES = bool('sqlite' not in settings.DATABASES['default']['ENGINE'])
 
 # check whether or not PIL is installed
 try:
@@ -102,17 +105,18 @@ class Person(models.Model):
             DateTimeRangeField,
         )
 
-        acquaintances = ArrayField(models.IntegerField())
-        data = JSONField()
-        hstore_data = HStoreField()
-        ci_char = CICharField(max_length=30)
-        ci_email = CIEmailField()
-        ci_text = CITextField()
-        int_range = IntegerRangeField()
-        bigint_range = BigIntegerRangeField()
-        float_range = FloatRangeField()
-        date_range = DateRangeField()
-        datetime_range = DateTimeRangeField()
+        if USING_POSTGRES:
+            acquaintances = ArrayField(models.IntegerField())
+            data = JSONField()
+            hstore_data = HStoreField()
+            ci_char = CICharField(max_length=30)
+            ci_email = CIEmailField()
+            ci_text = CITextField()
+            int_range = IntegerRangeField()
+            bigint_range = BigIntegerRangeField()
+            float_range = FloatRangeField()
+            date_range = DateRangeField()
+            datetime_range = DateTimeRangeField()
     except ImportError:
         # Skip PostgreSQL-related fields
         pass
@@ -120,7 +124,8 @@ class Person(models.Model):
     try:
         from django.contrib.postgres.fields.ranges import DecimalRangeField
 
-        decimal_range = DecimalRangeField()
+        if USING_POSTGRES:
+            decimal_range = DecimalRangeField()
     except ImportError:
         # Django version lower than 2.2
         pass

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -21,7 +21,7 @@ from .fields import (
     FakeListField,
 )
 
-USING_POSTGRES = bool('sqlite' not in settings.DATABASES['default']['ENGINE'])
+USING_POSTGRES = bool("sqlite" not in settings.DATABASES["default"]["ENGINE"])
 
 # check whether or not PIL is installed
 try:


### PR DESCRIPTION
This PR is a result from a comment in #85 from @xi about issues with `black` and with running the tests. So, this PRs updates:

1. The test code to not break with default `python -m pytest` command because it uses a SQLite DB;
2. Introduces a `make lint` command which matches the specs from our CI;
3. Move the `Contributing` section from our documetation to our repository README;

@amureki can you review this one for me? If you're ok with that, feel free to merge and I'll release a new model bakery's version.