### PR TITLE
Add `FloatRangeField` to list of supported fields in docs

### DIFF
--- a/docs/source/how_bakery_behaves.rst
+++ b/docs/source/how_bakery_behaves.rst
@@ -49,7 +49,7 @@ Currently supported fields
 * ``FileField``, ``ImageField``
 * ``JSONField``, ``ArrayField``, ``HStoreField``
 * ``CICharField``, ``CIEmailField``, ``CITextField``
-* ``DecimalRangeField``, ``IntegerRangeField``, ``BigIntegerRangeField``, ``DateRangeField``, ``DateTimeRangeField``
+* ``DecimalRangeField``, ``IntegerRangeField``, ``BigIntegerRangeField``, ``FloatRangeField``, ``DateRangeField``, ``DateTimeRangeField``
 
 Require ``django.contrib.gis`` in ``INSTALLED_APPS``:
 


### PR DESCRIPTION
(follow-up to #80)