### PR TITLE
Bring isort back to CI

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 black
+isort
 pillow
 pre-commit
 pytest

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -27,9 +27,7 @@ from .exceptions import (
     ModelNotFound,
     RecipeIteratorEmpty,
 )
-
-# Enable seq to be imported from baker
-from .utils import seq  # NoQA
+from .utils import seq  # NoQA: enable seq to be imported from baker
 from .utils import import_from_str
 
 recipes = None

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [travis]
 python =
     3.5: py35
-    3.6: py36,flake8,black
+    3.6: py36,flake8,isort,black
     3.7: py37
     3.8: py38
 
@@ -36,6 +36,11 @@ commands =
 deps=flake8
 basepython=python3
 commands=flake8 model_bakery {posargs}
+
+[testenv:isort]
+deps=isort
+basepython=python3
+commands=isort model_bakery {posargs}
 
 [testenv:black]
 deps=black

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands=flake8 model_bakery {posargs}
 [testenv:isort]
 deps=isort
 basepython=python3
-commands=isort model_bakery {posargs}
+commands=isort model_bakery --check-only {posargs}
 
 [testenv:black]
 deps=black


### PR DESCRIPTION
There seem to be a conflict between isort and black even with compatible configuration:
https://black.readthedocs.io/en/stable/the_black_code_style.html#how-black-wraps-lines

I did not dig deep, but fixing a comment helps here, so this feels good enough to me. :)