### PR TITLE
Fix JSONfield test import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/master)
 
 ### Added
-- Support to django 3.1 `JSONField` [PR #85](https://github.com/model-bakers/model_bakery/pull/85)
+- Support to django 3.1 `JSONField`[PR #85](https://github.com/model-bakers/model_bakery/pull/85) and [PR #106](https://github.com/model-bakers/model_bakery/pull/106)
 - [dev] Changelog reminder (GitHub action)
 
 ### Changed

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -90,7 +90,7 @@ class Person(models.Model):
     id_document = models.CharField(unique=True, max_length=10)
 
     try:
-        from django.models import JSONField
+        from django.db.models import JSONField
 
         data = JSONField()
     except ImportError:

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -21,7 +21,7 @@ from model_bakery.random_gen import gen_related
 from tests.generic import generators, models
 
 try:
-    from django.models import JSONField
+    from django.db.models import JSONField
 except ImportError:
     JSONField = None
 


### PR DESCRIPTION
Fixing tests import to match [generators.py#L50](https://github.com/model-bakers/model_bakery/blob/master/model_bakery/generators.py#L50):

```python
try:
    from django.db.models import JSONField
except ImportError:
    JSONField = None
```
