### PR TITLE
Correct field in recipe docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [dev] pre-commit to use local packages (so versions will match)
 - [dev] consistent use of pydocstyle
 - [dev] Updates to MANIFEST.in
+- [dev] Correct field in recipe docs
 
 ### Removed
 

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -117,7 +117,7 @@ You can define ``foreign_key`` relations:
     )
 
     history = Recipe(PurchaseHistory,
-        customer=foreign_key(customer)
+        owner=foreign_key(customer)
     )
 
 Notice that ``customer`` is a *recipe*.


### PR DESCRIPTION
Minor correction.

In the recipe docs [here](https://model-bakery.readthedocs.io/en/latest/recipes.html#recipes-with-foreign-keys),

I suppose `customer` should be `owner` for 'PurchaseHistory' recipe

going by the description below which says "You may be thinking: 'I can put the Customer model instance directly in the owner field'"