### PR TITLE
Add support for `suffix` in `seq` (fix #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [dev] pre-commit to use local packages (so versions will match)
 - [dev] consistent use of pydocstyle
 - [dev] Updates to MANIFEST.in
+- Support for `prefix` in `seq` values ([PR #111](https://github.com/model-bakers/model_bakery/pull/111) fixes [Issue #93](https://github.com/model-bakers/model_bakery/issues/93))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install model_bakery
 class Customer(models.Model):
     enjoy_jards_macale = models.BooleanField()
     name = models.CharField(max_length=30)
+    email = models.CharField(max_length=50)
     age = models.IntegerField()
     bio = models.TextField()
     days_since_last_login = models.BigIntegerField()

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install model_bakery
 class Customer(models.Model):
     enjoy_jards_macale = models.BooleanField()
     name = models.CharField(max_length=30)
-    email = models.CharField(max_length=50)
+    email = models.EmailField()
     age = models.IntegerField()
     bio = models.TextField()
     days_since_last_login = models.BigIntegerField()

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -11,6 +11,7 @@ File: **models.py** ::
         """
         enjoy_jards_macale = models.BooleanField()
         name = models.CharField(max_length=30)
+        email = models.EmailField()
         age = models.IntegerField()
         bio = models.TextField()
         days_since_last_login = models.BigIntegerField()
@@ -68,6 +69,7 @@ File: **models.py** ::
         """
         enjoy_jards_macale = models.BooleanField()
         name = models.CharField(max_length=30)
+        email = models.EmailField()
         age = models.IntegerField()
         bio = models.TextField()
         days_since_last_login = models.BigIntegerField()

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -225,6 +225,24 @@ Sometimes, you have a field with an unique value and using ``make`` can cause ra
 
 This will append a counter to strings to avoid uniqueness problems and it will sum the counter with numerical values.
 
+An optional ``suffix`` parameter can be supplied to augment the value for cases like generating emails
+or other strings with common suffixes.
+
+.. code-block:: python
+
+    >>> from model_bakery import.recipe import Recipe, seq
+    >>> from shop.models import Customer
+
+    >>> customer = Recipe(Customer, email=seq('user', suffix='@example.com'))
+
+    >>> customer = baker.make_recipe('shop.customer')
+    >>> customer.email
+    'user1@example.com'
+
+    >>> customer = baker.make_recipe('shop.customer')
+    >>> customer.email
+    'user2@example.com'
+
 Sequences and iterables can be used not only for recipes, but with ``baker`` as well:
 
 .. code-block:: python

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -45,5 +45,15 @@ def seq(value, increment_by=1, start=None, suffix=None):
             else:
                 yield series_date
     else:
+        if suffix and type(suffix) is not str:
+            raise TypeError("Sequences suffix can only be a string")
+
         for n in itertools.count(start or increment_by, increment_by):
-            yield value + type(value)(n) + (suffix or type(value)())
+            if suffix and type(value) is not str:
+                raise TypeError(
+                    "Sequences with suffix can only be used with text values"
+                )
+            elif suffix:
+                yield value + str(n) + suffix
+            else:
+                yield value + type(value)(n)

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -20,7 +20,7 @@ def import_from_str(import_string):
         return import_string
 
 
-def seq(value, increment_by=1, start=None):
+def seq(value, increment_by=1, start=None, suffix=None):
     if type(value) in [datetime.datetime, datetime.date, datetime.time]:
         if start:
             msg = "start parameter is ignored when using seq with date, time or datetime objects"
@@ -46,4 +46,4 @@ def seq(value, increment_by=1, start=None):
                 yield series_date
     else:
         for n in itertools.count(start or increment_by, increment_by):
-            yield value + type(value)(n)
+            yield value + type(value)(n) + (suffix or type(value)())

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -21,6 +21,27 @@ def import_from_str(import_string):
 
 
 def seq(value, increment_by=1, start=None, suffix=None):
+    """Generate a sequence of values based on a running count.
+
+    This function can be used to generate sequences of `int`, `float`,
+    `datetime`, `date`, `time`, or `str`: whatever the `type` is of the
+    provided `value`.
+
+    Args:
+        value (object): the value at which to begin generation (this will
+            be ignored for types `datetime`, `date`, and `time`)
+        increment_by (`int` or `float`, optional): the amount by which to
+            increment for each generated value (defaults to `1`)
+        start (`int` or `float`, optional): the value at which the sequence
+            will begin to add to `value` (if `value` is a `str`, `start` will
+            be appended to it)
+        suffix (`str`, optional): for `str` `value` sequences, this will be
+            appended to the end of each generated value (after the counting
+            value is appended)
+
+    Returns:
+        object: generated values for sequential data
+    """
     if type(value) in [datetime.datetime, datetime.date, datetime.time]:
         if start:
             msg = "start parameter is ignored when using seq with date, time or datetime objects"

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -45,11 +45,11 @@ def seq(value, increment_by=1, start=None, suffix=None):
             else:
                 yield series_date
     else:
-        if suffix and type(suffix) is not str:
+        if suffix and not isinstance(suffix, str):
             raise TypeError("Sequences suffix can only be a string")
 
         for n in itertools.count(start or increment_by, increment_by):
-            if suffix and type(value) is not str:
+            if suffix and not isinstance(value, str):
                 raise TypeError(
                     "Sequences with suffix can only be used with text values"
                 )

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -430,7 +430,7 @@ class TestSequences:
         # Bad suffix
         bob_person = person_recipe.extend(email=seq("bob", suffix=42))
         with pytest.raises(TypeError) as exc:
-            person = bob_person.make()
+            bob_person.make()
             assert str(exc.value) == "Sequences suffix can only be a string"
 
     def test_increment_for_strings_with_suffix_and_start(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -416,13 +416,19 @@ class TestSequences:
     def test_increment_for_strings_with_suffix(self):
         from model_bakery.recipe import seq  # NoQA
 
-        fred_person = person_recipe.extend(name=seq("fred", suffix="@example.com"))
+        fred_person = person_recipe.extend(email=seq("fred", suffix="@example.com"))
         person = fred_person.make()
-        assert person.name == "fred1@example.com"
+        assert person.email == "fred1@example.com"
         person = fred_person.make()
-        assert person.name == "fred2@example.com"
+        assert person.email == "fred2@example.com"
         person = fred_person.make()
-        assert person.name == "fred3@example.com"
+        assert person.email == "fred3@example.com"
+
+        # Bad suffix
+        bob_person = person_recipe.extend(email=seq("bob", suffix=42))
+        with pytest.raises(TypeError) as exc:
+            person = bob_person.make()
+            assert str(exc.value) == "Sequences suffix can only be a string"
 
     def test_increment_for_numbers(self):
         dummy = baker.make_recipe("tests.generic.serial_numbers")
@@ -456,16 +462,12 @@ class TestSequences:
     def test_increment_for_numbers_with_suffix(self):
         from model_bakery.recipe import seq  # NoQA
 
-        dummy = baker.make_recipe(
-            "tests.generic.serial_numbers", default_int_field=seq(1, suffix=1)
-        )
-        assert dummy.default_int_field == 3
-
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as exc:
             dummy = baker.make_recipe(
                 "tests.generic.serial_numbers",
-                default_int_field=seq(1, suffix="this should fail"),
+                default_int_field=seq(1, suffix='will not work')
             )
+            assert str(exc.value) == "Sequences with suffix can only be used with text values"
 
     def test_creates_unique_field_recipe_using_for_iterator(self):
         for i in range(1, 4):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -424,11 +424,27 @@ class TestSequences:
         person = fred_person.make()
         assert person.email == "fred3@example.com"
 
+    def test_increment_for_strings_with_bad_suffix(self):
+        from model_bakery.recipe import seq  # NoQA
+
         # Bad suffix
         bob_person = person_recipe.extend(email=seq("bob", suffix=42))
         with pytest.raises(TypeError) as exc:
             person = bob_person.make()
             assert str(exc.value) == "Sequences suffix can only be a string"
+
+    def test_increment_for_strings_with_suffix_and_start(self):
+        from model_bakery.recipe import seq  # NoQA
+
+        fred_person = person_recipe.extend(
+            email=seq("fred", start=5, suffix="@example.com")
+        )
+        person = fred_person.make()
+        assert person.email == "fred5@example.com"
+        person = fred_person.make()
+        assert person.email == "fred6@example.com"
+        person = fred_person.make()
+        assert person.email == "fred7@example.com"
 
     def test_increment_for_numbers(self):
         dummy = baker.make_recipe("tests.generic.serial_numbers")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -463,11 +463,14 @@ class TestSequences:
         from model_bakery.recipe import seq  # NoQA
 
         with pytest.raises(TypeError) as exc:
-            dummy = baker.make_recipe(
+            baker.make_recipe(
                 "tests.generic.serial_numbers",
-                default_int_field=seq(1, suffix='will not work')
+                default_int_field=seq(1, suffix="will not work"),
             )
-            assert str(exc.value) == "Sequences with suffix can only be used with text values"
+            assert (
+                str(exc.value)
+                == "Sequences with suffix can only be used with text values"
+            )
 
     def test_creates_unique_field_recipe_using_for_iterator(self):
         for i in range(1, 4):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -413,6 +413,17 @@ class TestSequences:
         person = baker.make_recipe("tests.generic.serial_person")
         assert person.name == "joe3"
 
+    def test_increment_for_strings_with_suffix(self):
+        from model_bakery.recipe import seq  # NoQA
+
+        fred_person = person_recipe.extend(name=seq("fred", suffix="@example.com"))
+        person = fred_person.make()
+        assert person.name == "fred1@example.com"
+        person = fred_person.make()
+        assert person.name == "fred2@example.com"
+        person = fred_person.make()
+        assert person.name == "fred3@example.com"
+
     def test_increment_for_numbers(self):
         dummy = baker.make_recipe("tests.generic.serial_numbers")
         assert dummy.default_int_field == 11
@@ -441,6 +452,20 @@ class TestSequences:
         assert dummy.default_int_field == 13
         assert dummy.default_decimal_field == Decimal("23.1")
         assert dummy.default_float_field == 4.23
+
+    def test_increment_for_numbers_with_suffix(self):
+        from model_bakery.recipe import seq  # NoQA
+
+        dummy = baker.make_recipe(
+            "tests.generic.serial_numbers", default_int_field=seq(1, suffix=1)
+        )
+        assert dummy.default_int_field == 3
+
+        with pytest.raises(TypeError):
+            dummy = baker.make_recipe(
+                "tests.generic.serial_numbers",
+                default_int_field=seq(1, suffix="this should fail"),
+            )
 
     def test_creates_unique_field_recipe_using_for_iterator(self):
         for i in range(1, 4):


### PR DESCRIPTION
# Add support for `suffix` in `seq` (fix #93)

## What
This change introduces the ability to append a common suffix on to values generated by `seq`.

Fixes #93 

## Why
Some fields may represent data that generally contains a common suffix, like in the case of emails. Mock data is therefore differentiated in the first portion of the field's value. An example of this:

```
fake.user1@example.com
fake.user2@example.com
...
```
By allowing an optionally supplied suffix, the `seq` function is able to append some common string onto its generated values.

## How
A `suffix` keyword argument was added to the `seq` function to allow the concatenation of a common suffix string onto a generated value. This will not work with types of `value` other than `str`. Tests have been added to cover the "happy" and some "sad" path use of the new keyword argument.

Example:

```python
from django.db import models
from model_bakery.recipe import Recipe, seq


class Person(models.Model):
    email = models.CharField(max_length=50)


person_recipe = Recipe(Person, email=seq('fake.user', suffix='example.com')

person_recipe.make().email  # 'fake.user1@example.com'
person_recipe.make().email  # 'fake.user2@example.com'
person_recipe.make().email  # 'fake.user3@example.com'
```

This PR also adds a section under "Sequences in recipes" to the documentation to provide example usage of the new keyword argument. Additionally, an `email` field is added to the `Customer` example model in the README.md to go along with the new section in the documentation.

_**Note:** the line altered in `seq` (shown below) takes into account that if no `suffix` argument is supplied, it will essentially append an un-initialized type of the same as the `value` input. For number types, this is equivalent to `0`._
```python
yield value + type(value)(n) + (suffix or type(value)())
```