### PR TITLE
Fix compatibility with Django 3.1 and actually run test against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [dev] CI switched to GitHub Actions
 - [dev] Freeze dev requirements
-- [dev] Add Django 3.1 to test matrix
+- [dev] Add Django 3.1 to test matrix [PR #103](https://github.com/model-bakers/model_bakery/pull/103) and [PR #112](https://github.com/model-bakers/model_bakery/pull/112)
 - [dev] pre-commit to use local packages (so versions will match)
 - [dev] consistent use of pydocstyle
 - [dev] Updates to MANIFEST.in
 - [dev] Correct field in recipe docs
+- [dev] Adjust imports for Django 3.1 compatibility [PR #112](https://github.com/model-bakers/model_bakery/pull/112)
 
 ### Removed
 

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -87,15 +87,17 @@ try:
         BigIntegerRangeField,
         DateRangeField,
         DateTimeRangeField,
-        FloatRangeField,
         IntegerRangeField,
     )
 except ImportError:
     IntegerRangeField = None
     BigIntegerRangeField = None
-    FloatRangeField = None
     DateRangeField = None
     DateTimeRangeField = None
+try:
+    from django.contrib.postgres.fields.ranges import FloatRangeField
+except ImportError:
+    FloatRangeField = None
 
 
 def _make_integer_gen_by_range(field_type: Any) -> Callable:

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -109,7 +109,6 @@ class Person(models.Model):
             BigIntegerRangeField,
             DateRangeField,
             DateTimeRangeField,
-            FloatRangeField,
             IntegerRangeField,
         )
 
@@ -122,11 +121,19 @@ class Person(models.Model):
             ci_text = CITextField()
             int_range = IntegerRangeField()
             bigint_range = BigIntegerRangeField()
-            float_range = FloatRangeField()
             date_range = DateRangeField()
             datetime_range = DateTimeRangeField()
     except ImportError:
         # Skip PostgreSQL-related fields
+        pass
+
+    try:
+        from django.contrib.postgres.fields.ranges import FloatRangeField
+
+        if settings.USING_POSTGRES:
+            float_range = FloatRangeField()
+    except ImportError:
+        # Django version greater or equal than 3.1
         pass
 
     try:

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -38,7 +38,6 @@ try:
         BigIntegerRangeField,
         DateRangeField,
         DateTimeRangeField,
-        FloatRangeField,
         IntegerRangeField,
     )
 except ImportError:
@@ -50,10 +49,13 @@ except ImportError:
     CITextField = None
     IntegerRangeField = None
     BigIntegerRangeField = None
-    FloatRangeField = None
     DateRangeField = None
     DateTimeRangeField = None
 
+try:
+    from django.contrib.postgres.fields.ranges import FloatRangeField
+except ImportError:
+    FloatRangeField = None
 try:
     from django.contrib.postgres.fields.ranges import DecimalRangeField
 except ImportError:
@@ -454,6 +456,10 @@ class TestCIStringFieldsFilling:
         assert isinstance(person.bigint_range.upper, int)
         assert person.bigint_range.lower < person.bigint_range.upper
 
+    @pytest.mark.skipif(
+        FloatRangeField is None,
+        reason="Django version does not support FloatRangeField",
+    )
     def test_filling_float_range_field(self, person):
         from psycopg2._range import NumericRange
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py35-django{111,20,21,22}-{postgresql,sqlite}
-    py{36,37,38}-django{111,20,21,22,30}-{postgresql,sqlite}
+    py{36,37,38}-django{111,20,21,22,30,31}-{postgresql,sqlite}
     flake8
     isort
     pydocstyle


### PR DESCRIPTION
`django.contrib.postgres.fields.FloatRangeField` has been removed in Django 3.1, see https://docs.djangoproject.com/en/3.1/releases/3.1/#features-removed-in-3-1