### PR TITLE
Fix _model annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fixed _model parameter annotations [PR #115](https://github.com/model-bakers/model_bakery/pull/115)
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -47,7 +47,7 @@ def _valid_quantity(quantity: Optional[Union[str, int]]) -> bool:
 
 
 def make(
-    _model: str,
+    _model: Union[str, Type[ModelBase]],
     _quantity: Optional[int] = None,
     make_m2m: bool = False,
     _save_kwargs: Optional[Dict] = None,
@@ -79,7 +79,9 @@ def make(
     )
 
 
-def prepare(_model: str, _quantity=None, _save_related=False, **attrs) -> Model:
+def prepare(
+    _model: Union[str, Type[ModelBase]], _quantity=None, _save_related=False, **attrs
+) -> Model:
     """Create but do not persist an instance from a given model.
 
     It fill the fields with random values or you can specify which
@@ -229,7 +231,10 @@ class Baker(object):
 
     @classmethod
     def create(
-        cls, _model: str, make_m2m: bool = False, create_files: bool = False
+        cls,
+        _model: Union[str, Type[ModelBase]],
+        make_m2m: bool = False,
+        create_files: bool = False,
     ) -> "Baker":
         """Create the baker class defined by the `BAKER_CUSTOM_CLASS` setting."""
         baker_class = _custom_baker_class() or cls

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -1,8 +1,9 @@
 import inspect
 import itertools
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Type, Union, cast
 
 from django.db.models import Model
+from django.db.models.base import ModelBase
 
 from . import baker
 from .exceptions import RecipeNotFound
@@ -12,7 +13,7 @@ finder = baker.ModelFinder()
 
 
 class Recipe(object):
-    def __init__(self, _model: str, **attrs) -> None:
+    def __init__(self, _model: Union[str, Type[ModelBase]], **attrs) -> None:
         self.attr_mapping = attrs
         self._model = _model
         # _iterator_backups will hold values of the form (backup_iterator, usable_iterator).


### PR DESCRIPTION
This fixes `_model` argument annotation in a few places where it can be either a class or str (I'm not sure whether it would be better to create an alias).