### PR TITLE
[116] Support Callable `default` and Always Use `default` If Present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fixes bug when field has callable `default` [PR #117](https://github.com/model-bakers/model_bakery/pull/117)
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -510,7 +510,11 @@ class Baker(object):
             self._remote_field(field).model, contenttypes.models.ContentType
         )
 
-        if field.name in self.attr_mapping:
+        if field.has_default():
+            if callable(field.default):
+                return field.default()
+            return field.default
+        elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]
         elif getattr(field, "choices"):
             generator = random_gen.gen_from_choices(field.choices)
@@ -520,8 +524,6 @@ class Baker(object):
             generator = generators.get(field.__class__)
         elif field.__class__ in self.type_mapping:
             generator = self.type_mapping[field.__class__]
-        elif field.has_default():
-            return field.default
         else:
             raise TypeError("%s is not supported by baker." % field.__class__)
 

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -267,9 +267,7 @@ class DummyBlankFieldsModel(models.Model):
 
 
 class ExtendedDefaultField(models.IntegerField):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("default", 42)
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class DummyDefaultFieldsModel(models.Model):
@@ -286,7 +284,7 @@ class DummyDefaultFieldsModel(models.Model):
     )
     default_email_field = models.EmailField(default="foo@bar.org")
     default_slug_field = models.SlugField(default="a-slug")
-    default_unknown_class_field = ExtendedDefaultField()
+    default_unknown_class_field = ExtendedDefaultField(default=42)
     default_callable_int_field = models.IntegerField(default=lambda: 12)
     default_callable_datetime_field = models.DateTimeField(default=now)
 

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import FileSystemStorage
+from django.utils.timezone import now
 
 from model_bakery.gis import BAKER_GIS
 from model_bakery.timezone import smart_datetime as datetime
@@ -265,6 +266,12 @@ class DummyBlankFieldsModel(models.Model):
     blank_text_field = models.TextField(max_length=300, blank=True)
 
 
+class ExtendedDefaultField(models.IntegerField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("default", 42)
+        super().__init__(*args, **kwargs)
+
+
 class DummyDefaultFieldsModel(models.Model):
     default_id = models.AutoField(primary_key=True)
     default_char_field = models.CharField(max_length=50, default="default")
@@ -279,6 +286,9 @@ class DummyDefaultFieldsModel(models.Model):
     )
     default_email_field = models.EmailField(default="foo@bar.org")
     default_slug_field = models.SlugField(default="a-slug")
+    default_unknown_class_field = ExtendedDefaultField()
+    default_callable_int_field = models.IntegerField(default=lambda: 12)
+    default_callable_datetime_field = models.DateTimeField(default=now)
 
 
 class DummyFileFieldModel(models.Model):

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -542,6 +542,15 @@ class TestFillBlanksTestCase:
         with pytest.raises(TypeError):
             baker.make(models.DummyBlankFieldsModel, _fill_optional=1)
 
+    def test_fill_optional_with_default(self):
+        dummy = baker.make(models.DummyDefaultFieldsModel, _fill_optional=True)
+        assert dummy.default_callable_int_field == 12
+        assert isinstance(dummy.default_callable_datetime_field, datetime.datetime)
+
+    def test_fill_optional_with_default_unknown_class(self):
+        dummy = baker.make(models.DummyDefaultFieldsModel, _fill_optional=True)
+        assert dummy.default_unknown_class_field == 42
+
 
 @pytest.mark.django_db
 class TestFillAutoFieldsTestCase:
@@ -572,6 +581,9 @@ class TestSkipDefaultsTestCase:
         assert dummy.default_decimal_field == Decimal("0")
         assert dummy.default_email_field == "foo@bar.org"
         assert dummy.default_slug_field == "a-slug"
+        assert dummy.default_unknown_class_field == 42
+        assert dummy.default_callable_int_field == 12
+        assert isinstance(dummy.default_callable_datetime_field, datetime.datetime)
 
 
 @pytest.mark.django_db

--- a/tests/test_extending_bakery.py
+++ b/tests/test_extending_bakery.py
@@ -28,6 +28,7 @@ class SadPeopleBaker(baker.Baker):
     attr_mapping = {
         "enjoy_jards_macale": gen_opposite,
         "like_metal_music": gen_opposite,
+        "name": gen_opposite,  # Use a field without `default`
     }
 
 
@@ -53,8 +54,8 @@ class TestLessSimpleExtendBaker:
         like_metal_music_field = Person._meta.get_field("like_metal_music")
         sad_people_factory = SadPeopleBaker(Person)
         person = sad_people_factory.make()
-        assert person.enjoy_jards_macale is not enjoy_jards_macale_field.default
-        assert person.like_metal_music is not like_metal_music_field.default
+        assert person.enjoy_jards_macale is enjoy_jards_macale_field.default
+        assert person.like_metal_music is like_metal_music_field.default
 
     @pytest.mark.parametrize("value", [18, 18.5, [], {}, True])
     def test_fail_pass_non_string_to_generator_required(self, value):

--- a/tests/test_extending_bakery.py
+++ b/tests/test_extending_bakery.py
@@ -57,6 +57,11 @@ class TestLessSimpleExtendBaker:
         assert person.enjoy_jards_macale is enjoy_jards_macale_field.default
         assert person.like_metal_music is like_metal_music_field.default
 
+    def test_kwarg_used_over_attr_mapping_generator(self):
+        sad_people_factory = SadPeopleBaker(Person)
+        person = sad_people_factory.make(name="test")
+        assert person.name == "test"
+
     @pytest.mark.parametrize("value", [18, 18.5, [], {}, True])
     def test_fail_pass_non_string_to_generator_required(self, value):
         teens_bakers_factory = TeenagerBaker(Person)


### PR DESCRIPTION
## What
This change fixes #116, the following bug:

> If a field is of a class that does not have a generator (default or provided by the user) also has a `default` value which is a callable, the generated value is returned as the callable, not the result of calling the same.

For instance:

```python
from django.db import models
from model_bakery import baker


class MyField(models.TextField):
    pass

class DummyModel(models.Model):
    test = MyField(default=lambda: "default value")


dummy = baker.make(DummyModel)

# Before fix
dummy.test  # <function <lambda> at 0x7f0eadb9dca0>

# After fix
dummy.test  # "default value"
```

This also addresses the fact that the `default` value for a field was not always being returned from `Baker.generate_value` since it was lower in the `if, elif, else` block which also checked for the generator function to use for that field's value.

_**Note:** This PR takes the stance that: if `default` is present, that value should be used unless an explicit `kwarg` for that field is supplied to `make`._

## Why
This will allow fields of classes that are unknown to `model_bakery`, yet have a desired `default` value, to be used without error.