### PR TITLE
[107] Add Instructions and Script To Run `postgis` Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/master)
 
 ### Added
+- [dev] Add instructions and script for running `postgres` and `postgis` tests.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,5 +47,5 @@ sudo apt update -y && sudo apt install -y binutils libproj-dev gdal-bin
 ./postgis-tests.sh
 ```
 
-That will spn up a `docker` container with `postgresql` and `postgis` enabled and run the full test
+That will spin up a `docker` container with `postgresql` and `postgis` enabled and run the full test
 suite.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,25 @@ make lint
 ```
 
 If you don't follow the step 4, your PR may fail due to `black`, `isort`, `flake8` or `pydocstyle` warnings.
+
+To run `postgresql` and `postgis` specific tests:
+
+1. [Install `docker`](https://docs.docker.com/get-docker/).
+
+2. Install the `postgis` dependencies. Follow the
+[instructions from the Django docs](https://docs.djangoproject.com/en/3.1/ref/contrib/gis/install/geolibs/):
+
+If you are on Ubuntu/Debian you run the following:
+
+```shell
+sudo apt update -y && sudo apt install -y binutils libproj-dev gdal-bin
+```
+
+3. Run the following script:
+
+```shell
+./postgis-tests.sh
+```
+
+That will spn up a `docker` container with `postgresql` and `postgis` enabled and run the full test
+suite.

--- a/postgis-tests.sh
+++ b/postgis-tests.sh
@@ -1,0 +1,23 @@
+# Set a different port than postgres' default (in case the user is already running postgres locally)
+export PGPORT=4111
+export PGUSER=postgres
+export PGPASSWORD=postgres
+export TEST_DB=postgis
+
+# Run the postgis container
+docker run --rm --name modelbakery -e POSTGRES_HOST_AUTH_METHOD=trust -p ${PGPORT}:5432 -d postgis/postgis:11-3.0
+
+# Wait a few seconds so the DB container can start up
+echo "Waiting for DB container..."
+sleep 4s
+
+# Enable all of the extensions needed on the template1 database
+docker exec modelbakery /bin/bash -c "psql template1 -c \"CREATE EXTENSION IF NOT EXISTS citext;\" -U postgres"
+docker exec modelbakery /bin/bash -c "psql template1 -c \"CREATE EXTENSION IF NOT EXISTS hstore;\" -U postgres"
+docker exec modelbakery /bin/bash -c "psql template1 -c \"CREATE EXTENSION IF NOT EXISTS postgis;\" -U postgres"
+
+# Run the tests
+python -m pytest
+
+# Spin down the postgis container
+docker stop modelbakery

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,15 @@ def pytest_configure():
 
     settings.configure(
         DATABASES={
-            "default": {"ENGINE": db_engine, "NAME": db_name, "HOST": "localhost"}
+            "default": {
+                "ENGINE": db_engine,
+                "NAME": db_name,
+                "HOST": "localhost",
+                # The following DB settings are only used for `postgresql` and `postgis`
+                "PORT": os.environ.get("PGPORT", ""),
+                "USER": os.environ.get("PGUSER", ""),
+                "PASSWORD": os.environ.get("PGPASSWORD", "")
+            }
         },
         INSTALLED_APPS=installed_apps,
         LANGUAGE_CODE="en",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def pytest_configure():
                 # The following DB settings are only used for `postgresql` and `postgis`
                 "PORT": os.environ.get("PGPORT", ""),
                 "USER": os.environ.get("PGUSER", ""),
-                "PASSWORD": os.environ.get("PGPASSWORD", "")
+                "PASSWORD": os.environ.get("PGPASSWORD", ""),
             }
         },
         INSTALLED_APPS=installed_apps,


### PR DESCRIPTION
## What
Fixes #107.

Instructions for running `postgres` and `postgis` tests locally have been added to `CONTRIBUTING.md`. The instructions explain a way to run the tests against a database that is run using `docker`.

A script, `postgis-tests.sh`, has been added to do the heavy lifting for the user (once the dependencies have been installed). It may be desired to turn that into a `make` target in the future.

## Why
This provides a clean and reproduceable way to run the `postgres` and `postgis` specific tests locally.

## How
Follow the instructions in the `CONTRIBUTING.md` file. Comment on this PR if anything does not work or is missing.