### PR TITLE
[52] Allow string values for `foriegn_key` from other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [dev] Add instructions and script for running `postgres` and `postgis` tests.
+- Add ability to pass `str` values to `foreign_key` for recipes from other modules [PR #120](https://github.com/model-bakers/model_bakery/pull/120)
 
 ### Changed
 - Fixed _model parameter annotations [PR #115](https://github.com/model-bakers/model_bakery/pull/115)

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -113,9 +113,9 @@ def foreign_key(recipe: Union[Recipe, str]) -> RecipeForeignKey:
             recipe = baker._recipe(recipe)
         except (AttributeError, ImportError, ValueError):
             # Probably not in another module, so load it from calling module
-            recipe = _load_recipe_from_calling_module(recipe)
+            recipe = _load_recipe_from_calling_module(cast(str, recipe))
 
-    return RecipeForeignKey(recipe)
+    return RecipeForeignKey(cast(Recipe, recipe))
 
 
 class related(object):  # FIXME

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -26,7 +26,7 @@ def import_from_str(import_string: Optional[Union[Callable, str]]) -> Any:
 def get_calling_module(levels_back: int) -> Optional[ModuleType]:
     """Get the module some number of stack frames back from the current one.
 
-    Make sure to account for the number of stacks between the "calling" code
+    Make sure to account for the number of frames between the "calling" code
     and the one that calls this function.
 
     Args:

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -1,7 +1,10 @@
 import datetime
 import importlib
+import inspect
 import itertools
 import warnings
+
+from types import ModuleType
 from typing import Any, Callable, Optional, Union
 
 from .timezone import tz_aware
@@ -19,6 +22,23 @@ def import_from_str(import_string: Optional[Union[Callable, str]]) -> Any:
         return getattr(module, field_name)
     else:
         return import_string
+
+
+def get_calling_module(levels_back: int) -> ModuleType:
+    """Get the module some number of stack frames back from the current one.
+
+    Make sure to account for the number of stacks between the "calling" code
+    and the one that calls this function.
+
+    Args:
+        levels_back (int): Number of stack frames back from the current
+
+    Returns:
+        (ModuleType): the module from which the code was called
+    """
+    frame = inspect.stack()[levels_back + 1][0]
+    return inspect.getmodule(frame)
+
 
 
 def seq(value, increment_by=1, start=None, suffix=None):

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -23,7 +23,7 @@ def import_from_str(import_string: Optional[Union[Callable, str]]) -> Any:
         return import_string
 
 
-def get_calling_module(levels_back: int) -> ModuleType:
+def get_calling_module(levels_back: int) -> Optional[ModuleType]:
     """Get the module some number of stack frames back from the current one.
 
     Make sure to account for the number of stacks between the "calling" code

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -3,7 +3,6 @@ import importlib
 import inspect
 import itertools
 import warnings
-
 from types import ModuleType
 from typing import Any, Callable, Optional, Union
 
@@ -38,7 +37,6 @@ def get_calling_module(levels_back: int) -> ModuleType:
     """
     frame = inspect.stack()[levels_back + 1][0]
     return inspect.getmodule(frame)
-
 
 
 def seq(value, increment_by=1, start=None, suffix=None):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -341,6 +341,18 @@ class TestForeignKey:
         exception = c.value
         assert str(exception) == "Not a recipe"
 
+    def test_load_from_other_module_recipe(self):
+        dog = Recipe(Dog, owner=foreign_key("tests.generic.person")).make()
+        assert dog.owner.name == "John Doe"
+
+    def test_fail_load_invalid_recipe(self):
+        with pytest.raises(AttributeError):
+            foreign_key("tests.generic.nonexisting_recipe")
+
+    def test_class_directly_with_string(self):
+        with pytest.raises(TypeError):
+            RecipeForeignKey("foo")
+
     def test_do_not_create_related_model(self):
         """It should not create another object when passing the object as argument."""
         person = baker.make_recipe("tests.generic.person")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
-import pytest
 from inspect import getmodule
 
-from model_bakery.utils import import_from_str, get_calling_module
+import pytest
+
+from model_bakery.utils import get_calling_module, import_from_str
 from tests.generic.models import User
 
 
@@ -30,11 +31,7 @@ def test_get_calling_module():
         return get_calling_module(2), get_calling_module(3)
 
     def dummy_method():
-        return (
-            *dummy_secondary_method(),
-            get_calling_module(1),
-            get_calling_module(2)
-        )
+        return (*dummy_secondary_method(), get_calling_module(1), get_calling_module(2))
 
     # Unpack results from the function chain
     sec_mod, sec_pytest_mod, dummy_mod, pytest_mod = dummy_method()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
+from inspect import getmodule
 
-from model_bakery.utils import import_from_str
+from model_bakery.utils import import_from_str, get_calling_module
 from tests.generic.models import User
 
 
@@ -13,3 +14,36 @@ def test_import_from_str():
 
     assert import_from_str("tests.generic.models.User") == User
     assert import_from_str(User) == User
+
+
+def test_get_calling_module():
+    # Reference to this very module
+    this_module = getmodule(test_get_calling_module)
+
+    # Once removed is the `pytest` module calling this function
+    pytest_module = get_calling_module(1)
+    assert pytest_module != this_module
+    assert "pytest" in pytest_module.__name__
+
+    # Test functions
+    def dummy_secondary_method():
+        return get_calling_module(2), get_calling_module(3)
+
+    def dummy_method():
+        return (
+            *dummy_secondary_method(),
+            get_calling_module(1),
+            get_calling_module(2)
+        )
+
+    # Unpack results from the function chain
+    sec_mod, sec_pytest_mod, dummy_mod, pytest_mod = dummy_method()
+
+    assert sec_mod == this_module
+    assert "pytest" in sec_pytest_mod.__name__
+    assert dummy_mod == this_module
+    assert "pytest" in pytest_mod.__name__
+
+    # Raise an `IndexError` when attempting to access too many frames removed
+    with pytest.raises(IndexError):
+        assert get_calling_module(100)


### PR DESCRIPTION
## What

This change set allows a caller of `foreign_key` to supply a recipe via a `str` value that refers to a recipe from another module. Up to now, if a `str` value was passed in to `foreign_key` it would attempt to load that recipe in the module from which `foreign_key` was called. That functionality is still present. It is used as a fallback if the `str` value provided does not refer to a recipe from another module.

Fixes #52.

## Why

This offers more flexibility to the use of `foreign_key` and does not require the caller to import the recipe that they want to use.

## How

The code for `foreign_key`, `RecipeForeignKey`, and `related` was refactored slightly to reduce code duplication for the logic of loading a recipe from the "calling module". In addition to that, since it is assumed that most users of `model_bakery` call `foreign_key` and do not instantiate `RecipeForeignKey` directly, the logic for loading a recipe from a given module path string and the fallback logic for loading from the "calling module" string were placed inside `foreign_key` and removed from `RecipeForeignKey`'s `__init__` method to make it cleaner. The `__init__` method now only accepts `Recipe` objects.

Docstrings were also added to some existing functions/classes and all new functions.

## Example Usage

**`people.baker_recipes.py`**
```python
person = Recipe(
    Person,
    name="John Doe"
)
```

**`dogs.baker_recipes.py`**
```python
dog = Recipe(Dog, breed="Pug", owner=foreign_key("people.person"))
```