### PR TITLE
Enable multi-database support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [dev] Drop Python 3.5 support as it is retired (https://www.python.org/downloads/release/python-3510/)
 
 ### Removed
+- [dev] Remove support for Django<2.2 ([more about Django supported versions](https://www.djangoproject.com/download/#supported-versions))
 
 ## [1.2.0](https://pypi.org/project/model-bakery/1.2.0/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
-- [dev] Add instructions and script for running `postgres` and `postgis` tests.
 - Add ability to pass `str` values to `foreign_key` for recipes from other modules [PR #120](https://github.com/model-bakers/model_bakery/pull/120)
+- Add new parameter `_using` to support multi database Django applications
+- [dev] Add instructions and script for running `postgres` and `postgis` tests.
 
 ### Changed
 - Fixed _model parameter annotations [PR #115](https://github.com/model-bakers/model_bakery/pull/115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add ability to pass `str` values to `foreign_key` for recipes from other modules [PR #120](https://github.com/model-bakers/model_bakery/pull/120)
-- Add new parameter `_using` to support multi database Django applications
+- Add new parameter `_using` to support multi database Django applications [PR #126](https://github.com/model-bakers/model_bakery/pull/126)
 - [dev] Add instructions and script for running `postgres` and `postgis` tests.
 
 ### Changed

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -215,3 +215,23 @@ It also works with ``prepare``:
 
     customers = baker.prepare('shop.Customer', _quantity=3)
     assert len(customers) == 3
+
+Multi-database support
+----------------------
+
+Model Bakery supports django application with more than one database.
+If you want to determine which datasase bakery should use, you have the ``_using`` parameter:
+
+
+.. code-block:: python
+
+    from model_bakery import baker
+
+    custom_db = "your_custom_db"
+    assert custom_db in settings.DATABASES
+    history = baker.make('shop.PurchaseHistory', _using=custom_db)
+    assert history in PurchaseHistory.objects.using(custom_db).all()
+    assert history.customer in Customer.objects.using(custom_db).all()
+    # default database tables with no data
+    assert not PurchaseHistory.objects.exists()
+    assert not Customer.objects.exists()

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -220,7 +220,7 @@ Multi-database support
 ----------------------
 
 Model Bakery supports django application with more than one database.
-If you want to determine which datasase bakery should use, you have the ``_using`` parameter:
+If you want to determine which database bakery should use, you have the ``_using`` parameter:
 
 
 .. code-block:: python

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -106,13 +106,13 @@ def _recipe(name: str) -> Any:
     return import_from_str(".".join((app, "baker_recipes", recipe_name)))
 
 
-def make_recipe(baker_recipe_name, _quantity=None, **new_attrs):
-    return _recipe(baker_recipe_name).make(_quantity=_quantity, **new_attrs)
+def make_recipe(baker_recipe_name, _quantity=None, _using="", **new_attrs):
+    return _recipe(baker_recipe_name).make(_quantity=_quantity, _using=_using, **new_attrs)
 
 
-def prepare_recipe(baker_recipe_name, _quantity=None, _save_related=False, **new_attrs):
+def prepare_recipe(baker_recipe_name, _quantity=None, _save_related=False, _using="", **new_attrs):
     return _recipe(baker_recipe_name).prepare(
-        _quantity=_quantity, _save_related=_save_related, **new_attrs
+        _quantity=_quantity, _save_related=_save_related, _using=_using, **new_attrs
     )
 
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -497,7 +497,7 @@ class Baker(object):
                         m2m_relation.source_field_name: instance,
                         m2m_relation.target_field_name: value,
                     }
-                    make(through_model, **base_kwargs)
+                    make(through_model, _using=self._using, **base_kwargs)
 
     def _remote_field(
         self, field: Union[ForeignKey, OneToOneField]

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -62,7 +62,9 @@ def make(
     fields you want to define its values by yourself.
     """
     _save_kwargs = _save_kwargs or {}
-    baker = Baker.create(_model, make_m2m=make_m2m, create_files=_create_files, _using=_using)
+    baker = Baker.create(
+        _model, make_m2m=make_m2m, create_files=_create_files, _using=_using
+    )
     if _valid_quantity(_quantity):
         raise InvalidQuantityException
 
@@ -81,7 +83,11 @@ def make(
 
 
 def prepare(
-    _model: Union[str, Type[ModelBase]], _quantity=None, _save_related=False, _using="", **attrs
+    _model: Union[str, Type[ModelBase]],
+    _quantity=None,
+    _save_related=False,
+    _using="",
+    **attrs
 ) -> Model:
     """Create but do not persist an instance from a given model.
 
@@ -107,10 +113,14 @@ def _recipe(name: str) -> Any:
 
 
 def make_recipe(baker_recipe_name, _quantity=None, _using="", **new_attrs):
-    return _recipe(baker_recipe_name).make(_quantity=_quantity, _using=_using, **new_attrs)
+    return _recipe(baker_recipe_name).make(
+        _quantity=_quantity, _using=_using, **new_attrs
+    )
 
 
-def prepare_recipe(baker_recipe_name, _quantity=None, _save_related=False, _using="", **new_attrs):
+def prepare_recipe(
+    baker_recipe_name, _quantity=None, _save_related=False, _using="", **new_attrs
+):
     return _recipe(baker_recipe_name).prepare(
         _quantity=_quantity, _save_related=_save_related, _using=_using, **new_attrs
     )

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -259,7 +259,7 @@ def gen_m2m(model, **attrs):
     return make(model, _quantity=MAX_MANY_QUANTITY, **attrs)
 
 
-gen_m2m.required = [_fk_model]  # type: ignore[attr-defined]
+gen_m2m.required = [_fk_model, "_using"]  # type: ignore[attr-defined]
 
 
 # GIS generators

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -249,7 +249,7 @@ def gen_related(model, **attrs):
     return make(model, **attrs)
 
 
-gen_related.required = [_fk_model]  # type: ignore[attr-defined]
+gen_related.required = [_fk_model, "_using"]  # type: ignore[attr-defined]
 gen_related.prepare = _prepare_related  # type: ignore[attr-defined]
 
 

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -62,7 +62,9 @@ class Recipe(object):
     def prepare(self, _using="", **attrs: Any) -> Union[Model, List[Model]]:
         defaults = {"_save_related": False}
         defaults.update(attrs)
-        return baker.prepare(self._model, _using=_using, **self._mapping(_using, defaults))
+        return baker.prepare(
+            self._model, _using=_using, **self._mapping(_using, defaults)
+        )
 
     def extend(self, **attrs) -> "Recipe":
         attr_mapping = self.attr_mapping.copy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,15 +18,18 @@ def pytest_configure():
     if test_db == "sqlite":
         db_engine = "django.db.backends.sqlite3"
         db_name = ":memory:"
+        extra_db_name = ":memory:"
     elif test_db == "postgresql":
         using_postgres_flag = True
         db_engine = "django.db.backends.postgresql_psycopg2"
         db_name = "postgres"
         installed_apps = ["django.contrib.postgres"] + installed_apps
+        extra_db_name = "extra_db"
     elif test_db == "postgis":
         using_postgres_flag = True
         db_engine = "django.contrib.gis.db.backends.postgis"
         db_name = "postgres"
+        extra_db_name = "extra_db"
         installed_apps = [
             "django.contrib.postgres",
             "django.contrib.gis",
@@ -49,12 +52,12 @@ def pytest_configure():
             },
             # Extra DB used to test multi database support
             EXTRA_DB: {
-                "ENGINE": "django.db.backends.sqlite3",
-                "NAME": ":memory:",
+                "ENGINE": db_engine,
+                "NAME": extra_db_name,
                 "HOST": "localhost",
-                "PORT": "",
-                "USER": "",
-                "PASSWORD": "",
+                "PORT": os.environ.get("PGPORT", ""),
+                "USER": os.environ.get("PGUSER", ""),
+                "PASSWORD": os.environ.get("PGPASSWORD", ""),
             }
         },
         INSTALLED_APPS=installed_apps,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,9 @@ def pytest_configure():
     else:
         raise NotImplementedError("Tests for % are not supported", test_db)
 
+    EXTRA_DB = "extra"
     settings.configure(
+        EXTRA_DB=EXTRA_DB,
         DATABASES={
             "default": {
                 "ENGINE": db_engine,
@@ -44,6 +46,15 @@ def pytest_configure():
                 "PORT": os.environ.get("PGPORT", ""),
                 "USER": os.environ.get("PGUSER", ""),
                 "PASSWORD": os.environ.get("PGPASSWORD", ""),
+            },
+            # Extra DB used to test multi database support
+            EXTRA_DB: {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+                "HOST": "localhost",
+                "PORT": "",
+                "USER": "",
+                "PASSWORD": "",
             }
         },
         INSTALLED_APPS=installed_apps,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def pytest_configure():
                 "PORT": os.environ.get("PGPORT", ""),
                 "USER": os.environ.get("PGUSER", ""),
                 "PASSWORD": os.environ.get("PGPASSWORD", ""),
-            }
+            },
         },
         INSTALLED_APPS=installed_apps,
         LANGUAGE_CODE="en",

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -10,6 +10,7 @@ from tests.generic.models import (
     DummyDefaultFieldsModel,
     DummyUniqueIntegerFieldModel,
     Person,
+    School,
 )
 
 person = Recipe(
@@ -71,6 +72,8 @@ dog_with_more_friends = dog.extend(
 extended_dog = dog.extend(
     breed="Super basset",
 )
+
+paulo_freire_school = Recipe(School, name="Escola Municipal Paulo Freire")
 
 
 class SmallDogRecipe(Recipe):

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -317,7 +317,7 @@ class Ambiguous(models.Model):
 
 
 class School(models.Model):
-    name = models.CharField(max_length=10)
+    name = models.CharField(max_length=50)
     students = models.ManyToManyField(Person, through="SchoolEnrollment")
 
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -634,8 +634,8 @@ class TestBakerAllowsSaveParameters(TestCase):
         dog1, dog2 = baker.make(
             models.ModelWithOverridedSave, _save_kwargs={"owner": owner}, _quantity=2
         )
-        assert owner == dog1.owner
-        assert owner == dog2.owner
+        assert dog1.owner == owner
+        assert dog2.owner == owner
 
     def test_allow_user_to_specify_database_via_save_kwargs_for_retro_compatibility(
         self,
@@ -643,7 +643,7 @@ class TestBakerAllowsSaveParameters(TestCase):
         profile = baker.make(models.Profile, _save_kwargs={"using": settings.EXTRA_DB})
         qs = models.Profile.objects.using(settings.EXTRA_DB).all()
 
-        assert 1 == qs.count()
+        assert qs.count() == 1
         assert profile in qs
 
 
@@ -654,17 +654,17 @@ class TestBakerSupportsMultiDatabase(TestCase):
         profile = baker.make(models.Profile, _using=settings.EXTRA_DB)
         qs = models.Profile.objects.using(settings.EXTRA_DB).all()
 
-        assert 1 == qs.count()
+        assert qs.count() == 1
         assert profile in qs
 
     def test_related_fk_database_speficied_via_using_kwarg(self):
         dog = baker.make(models.Dog, _using=settings.EXTRA_DB)
         dog_qs = models.Dog.objects.using(settings.EXTRA_DB).all()
-        assert 1 == dog_qs.count()
+        assert dog_qs.count() == 1
         assert dog in dog_qs
 
         person_qs = models.Person.objects.using(settings.EXTRA_DB).all()
-        assert 1 == person_qs.count()
+        assert person_qs.count() == 1
         assert dog.owner in person_qs
 
     def test_related_fk_database_speficied_via_using_kwarg_combined_with_quantity(self):
@@ -672,8 +672,8 @@ class TestBakerSupportsMultiDatabase(TestCase):
         dog_qs = models.Dog.objects.using(settings.EXTRA_DB).all()
         person_qs = models.Person.objects.using(settings.EXTRA_DB).all()
 
-        assert 5 == person_qs.count()
-        assert 5 == dog_qs.count()
+        assert person_qs.count() == 5
+        assert dog_qs.count() == 5
         for dog in dogs:
             assert dog in dog_qs
             assert dog.owner in person_qs
@@ -681,7 +681,7 @@ class TestBakerSupportsMultiDatabase(TestCase):
     def test_allow_recipe_to_specify_database_via_using(self):
         dog = baker.make_recipe("generic.homeless_dog", _using=settings.EXTRA_DB)
         qs = models.Dog.objects.using(settings.EXTRA_DB).all()
-        assert 1 == qs.count()
+        assert qs.count() == 1
         assert dog in qs
 
     def test_recipe_related_fk_database_specified_via_using_kwarg(self):
@@ -690,19 +690,18 @@ class TestBakerSupportsMultiDatabase(TestCase):
         person_qs = models.Person.objects.using(settings.EXTRA_DB).all()
         dog.refresh_from_db()
         assert dog.owner
-        assert 1 == dog_qs.count()
+        assert dog_qs.count() == 1
         assert dog in dog_qs
-        assert 1 == person_qs.count()
+        assert person_qs.count() == 1
         assert dog.owner in person_qs
 
     def test_recipe_related_fk_database_specified_via_using_kwarg_and_quantity(self):
         dogs = baker.make_recipe("generic.dog", _using=settings.EXTRA_DB, _quantity=5)
         dog_qs = models.Dog.objects.using(settings.EXTRA_DB).all()
         person_qs = models.Person.objects.using(settings.EXTRA_DB).all()
-        assert 5 == dog_qs.count()
-        assert (
-            1 == person_qs.count()
-        )  # since we're using recipes, all dogs belongs to the same owner
+        assert dog_qs.count() == 5
+        # since we're using recipes, all dogs belongs to the same owner
+        assert person_qs.count() == 1
         for dog in dogs:
             dog.refresh_from_db()
             assert dog in dog_qs
@@ -711,14 +710,14 @@ class TestBakerSupportsMultiDatabase(TestCase):
     def test_related_m2m_database_speficied_via_using_kwarg(self):
         baker.make(models.Dog, _using=settings.EXTRA_DB, make_m2m=True)
         dog_qs = models.Dog.objects.using(settings.EXTRA_DB).all()
-        assert MAX_MANY_QUANTITY + 1 == dog_qs.count()
+        assert dog_qs.count() == MAX_MANY_QUANTITY + 1
         assert not models.Dog.objects.exists()
 
     def test_related_m2m_database_speficied_via_using_kwarg_and_quantity(self):
         qtd = 3
         baker.make(models.Dog, _using=settings.EXTRA_DB, make_m2m=True, _quantity=qtd)
         dog_qs = models.Dog.objects.using(settings.EXTRA_DB).all()
-        assert MAX_MANY_QUANTITY * qtd + qtd == dog_qs.count()
+        assert dog_qs.count() == MAX_MANY_QUANTITY * qtd + qtd
         assert not models.Dog.objects.exists()
 
     def test_create_many_to_many_with_through_option_and_custom_db(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -233,7 +233,7 @@ class TestExecutingRecipes:
     def test_save_related_instances_on_prepare_recipe(self):
         dog = baker.prepare_recipe("tests.generic.homeless_dog")
         assert not dog.id
-        assert not dog.owner.id
+        assert not dog.owner_id
 
         dog = baker.prepare_recipe("tests.generic.homeless_dog", _save_related=True)
         assert not dog.id

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py35-django{111,20,21,22}-{postgresql,sqlite}
-    py{36,37,38}-django{111,20,21,22,30,31}-{postgresql,sqlite}
+    py35-django{22}-{postgresql,sqlite}
+    py{36,37,38}-django{22,30,31}-{postgresql,sqlite}
     py{39}-django{31}-{postgresql,sqlite}
     flake8
     isort
@@ -26,9 +26,6 @@ deps =
     pillow
     pytest
     pytest-django
-    django111: Django>=1.11,<1.12
-    django20: Django==2.0
-    django21: Django==2.1
     django22: Django==2.2
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
Fixes #94

This PR introduces the new parameter `_using` to baker API so callers can specify which database they want to use. If no value, it uses django's default DB.

This PR was created during Python Brasil 2020 with the amazing help from @flavioamieiro @rhenanbartels @mazulo @berrondo