### PR TITLE
[#65] Add `_bulk_create` parameter to `make`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #129](https://github.com/model-bakers/model_bakery/pull/129)
+
 ### Changed
 
 - Type hinting fixed for Recipe "_model" parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #129](https://github.com/model-bakers/model_bakery/pull/129)
+- Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
 
 ### Changed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -72,11 +72,7 @@ def make(
     if _quantity and _bulk_create:
         return baker.model._base_manager.bulk_create(
             [
-                baker.prepare(
-                    _save_kwargs=_save_kwargs,
-                    _refresh_after_create=_refresh_after_create,
-                    **attrs
-                )
+                baker.prepare(_save_kwargs=_save_kwargs, **attrs)
                 for _ in range(_quantity)
             ]
         )

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -54,6 +54,7 @@ def make(
     _refresh_after_create: bool = False,
     _create_files: bool = False,
     _using: str = "",
+    _bulk_create: Optional[bool] = False,
     **attrs: Any
 ):
     """Create a persisted instance from a given model its associated models.
@@ -68,7 +69,18 @@ def make(
     if _valid_quantity(_quantity):
         raise InvalidQuantityException
 
-    if _quantity:
+    if _quantity and _bulk_create:
+        return baker.model._base_manager.bulk_create(
+            [
+                baker.prepare(
+                    _save_kwargs=_save_kwargs,
+                    _refresh_after_create=_refresh_after_create,
+                    **attrs
+                )
+                for _ in range(_quantity)
+            ]
+        )
+    elif _quantity:
         return [
             baker.make(
                 _save_kwargs=_save_kwargs,
@@ -77,6 +89,7 @@ def make(
             )
             for _ in range(_quantity)
         ]
+
     return baker.make(
         _save_kwargs=_save_kwargs, _refresh_after_create=_refresh_after_create, **attrs
     )

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -54,7 +54,7 @@ def make(
     _refresh_after_create: bool = False,
     _create_files: bool = False,
     _using: str = "",
-    _bulk_create: Optional[bool] = False,
+    _bulk_create: bool = False,
     **attrs: Any
 ):
     """Create a persisted instance from a given model its associated models.

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -409,3 +409,9 @@ class AbstractModel(models.Model):
 
 class SubclassOfAbstract(AbstractModel):
     height = models.IntegerField()
+
+
+class NonStandardManager(models.Model):
+    name = models.CharField(max_length=30)
+
+    manager = models.Manager()

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.db import connection
 from django.db.models import Manager
 from django.db.models.signals import m2m_changed
 from django.test import TestCase
@@ -27,6 +28,45 @@ def test_import_seq_from_baker():
         from model_bakery.baker import seq  # NoQA
     except ImportError:
         pytest.fail("{} raised".format(ImportError.__name__))
+
+
+class QueryCount:
+    """
+    Keep track of db calls.
+
+    Example:
+    ========
+
+        qc = QueryCount()
+
+        with qc.start_count():
+            MyModel.objects.get(pk=1)
+            MyModel.objects.create()
+
+        qc.count  # 2
+
+    """
+
+    def __init__(self):
+        self.count = 0
+
+    def __call__(self, execute, sql, params, many, context):
+        """
+        `django.db.connection.execute_wrapper` callback
+
+        https://docs.djangoproject.com/en/3.1/topics/db/instrumentation/
+        """
+        self.count += 1
+        execute(sql, params, many, context)
+
+    def start_count(self):
+        """
+        Reset query count to 0 and return context manager for wrapping db
+        queries.
+        """
+        self.count = 0
+
+        return connection.execute_wrapper(self)
 
 
 class TestsModelFinder:
@@ -119,6 +159,21 @@ class TestsBakerRepeatedCreatesSimpleModel:
 
         people = baker.make(models.Person, _quantity=5, name="George Washington")
         assert all(p.name == "George Washington" for p in people)
+
+    def test_make_quantity_respecting_bulk_create_parameter(self):
+        queries = QueryCount()
+
+        with queries.start_count():
+            baker.make(models.Person, _quantity=5, _bulk_create=True)
+            assert queries.count == 1
+            assert models.Person.objects.count() == 5
+
+        with queries.start_count():
+            people = baker.make(
+                models.Person, name="George Washington", _quantity=5, _bulk_create=True
+            )
+            assert all(p.name == "George Washington" for p in people)
+            assert queries.count == 1
 
     def test_make_raises_correct_exception_if_invalid_quantity(self):
         with pytest.raises(InvalidQuantityException):


### PR DESCRIPTION
- This enables the use of `bulk_create` for the models that are
  created with `_quantity` supplied. This could offer performance
  advantages when creating large quantities of data.
- It works by instead "preparing" the models and supplying them
  to the `_base_manager.bulk_create`.

Fixes #65 