### PR TITLE
Update packages before installing it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Install PostgreSQL dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y gdal-bin
           psql -c "CREATE ROLE runner SUPERUSER LOGIN CREATEDB;" -U postgres -h localhost -p 5432
           psql template1 -c "CREATE EXTENSION citext;" -U postgres -h localhost -p 5432


### PR DESCRIPTION
This would prevent the error `E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler73_0.62.0-2ubuntu2.10_amd64.deb  404  Not Found [IP: 52.250.76.244 80]`.
https://github.community/t/sudo-apt-install-fails-with-failed-to-fetch-http-security-ubuntu-com-404-not-found-ip/17075