### PR TITLE
Reproduce: Cannot call baker.make() with ForeignKey default=pk, only actual model instance

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -538,8 +538,8 @@ class Baker(object):
             if callable(default):
                 default = default()
             if is_fk:
-                # Pass instance instead of pk/<to_field> value. In case a c
-                # custom to_field is set, Django should populate 
+                # Pass instance instead of pk/<to_field> value. In case a
+                # custom 'to_field' is set, Django should populate 
                 # field.to_fields with a single string.
                 key = "pk"
                 if field.to_fields and field.to_fields[0] is not None:

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -538,8 +538,14 @@ class Baker(object):
             if callable(default):
                 default = default()
             if is_fk:
-                # Pass instance instead of pk value
-                default = remote_field.model.objects.get(pk=default)
+                # Pass instance instead of pk/<to_field> value. In case a c
+                # custom to_field is set, Django should populate 
+                # field.to_fields with a single string.
+                key = "pk"
+                if field.to_fields and field.to_fields[0] is not None:
+                    key = field.to_fields[0]
+                instance_kwargs = {key: default}
+                default = remote_field.model.objects.get(**instance_kwargs)
             return default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -538,14 +538,8 @@ class Baker(object):
             if callable(default):
                 default = default()
             if is_fk:
-                # Pass instance instead of pk/<to_field> value. In case a c
-                # custom to_field is set, Django should populate 
-                # field.to_fields with a single string.
-                key = "pk"
-                if field.to_fields and field.to_fields[0] is not None:
-                    key = field.to_fields[0]
-                instance_kwargs = {key: default}
-                default = remote_field.model.objects.get(**instance_kwargs)
+                # Pass instance instead of pk value
+                default = remote_field.model.objects.get(pk=default)
             return default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -538,8 +538,8 @@ class Baker(object):
             if callable(default):
                 default = default()
             if is_fk:
-                # Pass instance instead of pk/<to_field> value. In case a
-                # custom 'to_field' is set, Django should populate 
+                # Pass instance instead of pk/<to_field> value. In case a c
+                # custom to_field is set, Django should populate 
                 # field.to_fields with a single string.
                 key = "pk"
                 if field.to_fields and field.to_fields[0] is not None:

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -527,20 +527,14 @@ class Baker(object):
         `attr_mapping` and `type_mapping` can be defined easily overwriting the
         model.
         """
-        is_fk = isinstance(field, ForeignKey)
-        remote_field = self._remote_field(field)
-        is_content_type_fk = is_fk and issubclass(
-            remote_field.model, contenttypes.models.ContentType
+        is_content_type_fk = isinstance(field, ForeignKey) and issubclass(
+            self._remote_field(field).model, contenttypes.models.ContentType
         )
 
         if field.has_default():
-            default = field.default
-            if callable(default):
-                default = default()
-            if is_fk:
-                # Pass instance instead of pk value
-                default = remote_field.model.objects.get(pk=default)
-            return default
+            if callable(field.default):
+                return field.default()
+            return field.default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]
         elif getattr(field, "choices"):

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -527,14 +527,20 @@ class Baker(object):
         `attr_mapping` and `type_mapping` can be defined easily overwriting the
         model.
         """
-        is_content_type_fk = isinstance(field, ForeignKey) and issubclass(
-            self._remote_field(field).model, contenttypes.models.ContentType
+        is_fk = isinstance(field, ForeignKey)
+        remote_field = self._remote_field(field)
+        is_content_type_fk = is_fk and issubclass(
+            remote_field.model, contenttypes.models.ContentType
         )
 
         if field.has_default():
-            if callable(field.default):
-                return field.default()
-            return field.default
+            default = field.default
+            if callable(default):
+                default = default()
+            if is_fk:
+                # Pass instance instead of pk value
+                default = remote_field.model.objects.get(pk=default)
+            return default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]
         elif getattr(field, "choices"):

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -541,10 +541,11 @@ class Baker(object):
                 # Pass instance instead of pk/<to_field> value. In case a
                 # custom 'to_field' is set, Django should populate 
                 # field.to_fields with a single string.
-                default_key = "pk"
+                key = "pk"
                 if field.to_fields and field.to_fields[0] is not None:
-                    default_key = field.to_fields[0]
-                default = remote_field.model.objects.get(**{default_key: default})
+                    key = field.to_fields[0]
+                instance_kwargs = {key: default}
+                default = remote_field.model.objects.get(**instance_kwargs)
             return default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -541,11 +541,10 @@ class Baker(object):
                 # Pass instance instead of pk/<to_field> value. In case a
                 # custom 'to_field' is set, Django should populate 
                 # field.to_fields with a single string.
-                key = "pk"
+                default_key = "pk"
                 if field.to_fields and field.to_fields[0] is not None:
-                    key = field.to_fields[0]
-                instance_kwargs = {key: default}
-                default = remote_field.model.objects.get(**instance_kwargs)
+                    default_key = field.to_fields[0]
+                default = remote_field.model.objects.get(**{default_key: default})
             return default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -254,6 +254,23 @@ class DummyGenericRelationModel(models.Model):
     relation = GenericRelation(DummyGenericForeignKeyModel)
 
 
+class NamedThing(models.Model):
+    name = models.CharField(max_length=64)
+
+
+def get_default_namedthing_id():
+    instance, _ = NamedThing.objects.get_or_create(name="Default")
+    return instance.id
+
+
+class DummyForeignKeyWithDefaultIdModel(models.Model):
+    named_thing = models.ForeignKey(
+        "NamedThing",
+        default=get_default_namedthing_id,
+        on_delete=models.SET_DEFAULT,
+    )
+
+
 class DummyNullFieldsModel(models.Model):
     null_foreign_key = models.ForeignKey(
         "DummyBlankFieldsModel", null=True, on_delete=models.CASCADE

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -255,18 +255,19 @@ class DummyGenericRelationModel(models.Model):
 
 
 class NamedThing(models.Model):
-    name = models.CharField(max_length=64)
+    name = models.CharField(primary_key=True, max_length=64)
 
 
-def get_default_namedthing_id():
+def get_default_namedthing_name():
     instance, _ = NamedThing.objects.get_or_create(name="Default")
-    return instance.id
+    return instance.name
 
 
 class DummyForeignKeyWithDefaultIdModel(models.Model):
     named_thing = models.ForeignKey(
-        "NamedThing",
-        default=get_default_namedthing_id,
+        NamedThing,
+        default=get_default_namedthing_name,
+        to_field="name",
         on_delete=models.SET_DEFAULT,
     )
 

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -255,19 +255,18 @@ class DummyGenericRelationModel(models.Model):
 
 
 class NamedThing(models.Model):
-    name = models.CharField(primary_key=True, max_length=64)
+    name = models.CharField(max_length=64)
 
 
-def get_default_namedthing_name():
+def get_default_namedthing_id():
     instance, _ = NamedThing.objects.get_or_create(name="Default")
-    return instance.name
+    return instance.id
 
 
 class DummyForeignKeyWithDefaultIdModel(models.Model):
     named_thing = models.ForeignKey(
-        NamedThing,
-        default=get_default_namedthing_name,
-        to_field="name",
+        "NamedThing",
+        default=get_default_namedthing_id,
         on_delete=models.SET_DEFAULT,
     )
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -277,6 +277,13 @@ class TestFillingGenericForeignKeyField:
 
 
 @pytest.mark.django_db
+class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
+    def test_filling_foreignkey_with_default_id(self):
+        dummy = baker.make(models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default")
+        assert dummy.named_thing.id == models.get_default_namedthing_id()
+
+
+@pytest.mark.django_db
 class TestsFillingFileField:
     def test_filling_file_field(self):
         dummy = baker.make(models.DummyFileFieldModel, _create_files=True)

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -279,7 +279,9 @@ class TestFillingGenericForeignKeyField:
 @pytest.mark.django_db
 class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
     def test_filling_foreignkey_with_default_id(self):
-        dummy = baker.make(models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default")
+        dummy = baker.make(
+            models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default"
+        )
         assert dummy.named_thing.id == models.get_default_namedthing_id()
 
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -279,11 +279,8 @@ class TestFillingGenericForeignKeyField:
 @pytest.mark.django_db
 class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
     def test_filling_foreignkey_with_default_id(self):
-        dummy = baker.make(
-            models.DummyForeignKeyWithDefaultIdModel, 
-            named_thing__name="Default",
-        )
-        assert dummy.named_thing.name == models.get_default_namedthing_name()
+        dummy = baker.make(models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default")
+        assert dummy.named_thing.id == models.get_default_namedthing_id()
 
 
 @pytest.mark.django_db

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -279,8 +279,11 @@ class TestFillingGenericForeignKeyField:
 @pytest.mark.django_db
 class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
     def test_filling_foreignkey_with_default_id(self):
-        dummy = baker.make(models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default")
-        assert dummy.named_thing.id == models.get_default_namedthing_id()
+        dummy = baker.make(
+            models.DummyForeignKeyWithDefaultIdModel, 
+            named_thing__name="Default",
+        )
+        assert dummy.named_thing.name == models.get_default_namedthing_name()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
See  #136

I tried to fix the problem by passing a model instance as the default within baker.generate_value() instead of passing a pk/id/to_field value, and that even passed all tests, but using this version model_bakery within our own test suite actually broke many, many tests, so I reverted that for now.

For now this simply reproduces the problem as a starting point for a fix. To reproduce run:

```bash
$ pytest tests/ -k test_filling_foreignkey_with_default_id
```