### PR TITLE
Allows import_from_str to import from inputs like app_name.ModelName 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
 - Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/134)
-- Add the functionality to import receipes using `app_name.receipe_name`
+- Add the functionality to import recipes using `app_name.recipe_name`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
-- Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/134)
+- Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/140)
 - Add the functionality to import recipes using `app_name.recipe_name`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
 - Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/134)
+- Add the functionality to import receipes using `app_name.receipe_name`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
+- Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/134)
 
 ### Changed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -117,8 +117,12 @@ def prepare(
 
 
 def _recipe(name: str) -> Any:
-    app, recipe_name = name.rsplit(".", 1)
-    return import_from_str(".".join((app, "baker_recipes", recipe_name)))
+    app_name, recipe_name = name.rsplit(".", 1)
+    if "." in app_name:  # probably full path, not app name
+        pkg = app_name
+    else:
+        pkg = apps.get_app_config(app_name).module.__package__
+    return import_from_str(".".join((pkg, "baker_recipes", recipe_name)))
 
 
 def make_recipe(baker_recipe_name, _quantity=None, _using="", **new_attrs):

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -25,7 +25,6 @@ def import_from_str(import_string: Optional[Union[Callable, str]]) -> Any:
     if isinstance(import_string, str):
         path, field_name = import_string.rsplit(".", 1)
 
-        # is it a Django model in the app_name.ModelName convention?
         if apps:
             model = apps.all_models.get(path, {}).get(field_name.lower())
             if model:

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -6,6 +6,13 @@ import warnings
 from types import ModuleType
 from typing import Any, Callable, Optional, Union
 
+try:
+    from django.apps import apps
+except ModuleNotFoundError:
+    # probably we are importing this module from setup.py, before installing
+    # the requirements (and we don't need Django at this point)
+    apps = None
+
 from .timezone import tz_aware
 
 
@@ -17,6 +24,13 @@ def import_from_str(import_string: Optional[Union[Callable, str]]) -> Any:
     """
     if isinstance(import_string, str):
         path, field_name = import_string.rsplit(".", 1)
+
+        # is it a Django model in the app_name.ModelName convention?
+        if apps:
+            model = apps.all_models.get(path, {}).get(field_name.lower())
+            if model:
+                return model
+
         module = importlib.import_module(path)
         return getattr(module, field_name)
     else:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -43,7 +43,7 @@ def test_import_seq_from_recipe():
 
 def test_import_recipes():
     """Test imports works both for full import paths and for
-    `app_name.receipe_name` strings."""
+    `app_name.recipe_name` strings."""
     assert baker.prepare_recipe("generic.dog"), baker.prepare_recipe(
         "tests.generic.dog"
     )

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -41,6 +41,14 @@ def test_import_seq_from_recipe():
         pytest.fail("{} raised".format(ImportError.__name__))
 
 
+def test_import_recipes():
+    """Test imports works both for full import paths and for
+    `app_name.receipe_name` strings."""
+    assert baker.prepare_recipe("generic.dog"), baker.prepare_recipe(
+        "tests.generic.dog"
+    )
+
+
 @pytest.mark.django_db
 class TestDefiningRecipes:
     def test_flat_model_make_recipe_with_the_correct_attributes(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -45,7 +45,7 @@ def test_import_recipes():
     """Test imports works both for full import paths and for
     `app_name.recipe_name` strings."""
     assert baker.prepare_recipe("generic.Dog"), baker.prepare_recipe(
-        "tests.generic.dog"
+        "tests.generic.Dog"
     )
 
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -44,8 +44,8 @@ def test_import_seq_from_recipe():
 def test_import_recipes():
     """Test imports works both for full import paths and for
     `app_name.recipe_name` strings."""
-    assert baker.prepare_recipe("generic.Dog"), baker.prepare_recipe(
-        "tests.generic.Dog"
+    assert baker.prepare_recipe("generic.dog"), baker.prepare_recipe(
+        "tests.generic.dog"
     )
 
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -44,7 +44,7 @@ def test_import_seq_from_recipe():
 def test_import_recipes():
     """Test imports works both for full import paths and for
     `app_name.recipe_name` strings."""
-    assert baker.prepare_recipe("generic.dog"), baker.prepare_recipe(
+    assert baker.prepare_recipe("generic.Dog"), baker.prepare_recipe(
         "tests.generic.dog"
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ def test_import_from_str():
 
     assert import_from_str("tests.generic.models.User") == User
     assert import_from_str(User) == User
+    assert import_from_str("generic.User") == User
 
 
 def test_get_calling_module():


### PR DESCRIPTION
If the reasoning in #139 makes sense (yep, it might not), this is a draft for the fix.

Locally I had to create `tests/__init__.py` to run tests, is that expected?
