### PR TITLE
Drop obsolete `model_bakery.timezone.now`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`
 
 ### Removed
+- `model_bakery.timezone.now` fallback (use `django.utils.timezone.now` instead)
 
 
 ## [1.2.1](https://pypi.org/project/model-bakery/1.2.1/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Type hinting fixed for Recipe "_model" parameter
+- Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`
 
 ### Removed
 

--- a/model_bakery/__about__.py
+++ b/model_bakery/__about__.py
@@ -1,0 +1,5 @@
+__version__ = "1.2.1"
+__author__ = "berinfontes"
+__email__ = "bernardoxhc@gmail.com"
+__url__ = "https://github.com/model-bakers/model_bakery"
+__license__ = "Apache 2.0"

--- a/model_bakery/__init__.py
+++ b/model_bakery/__init__.py
@@ -1,8 +1,1 @@
-"""Model Bakery module configuration."""
-__version__ = "1.2.1"
-__title__ = "model_bakery"
-__author__ = "Vanderson Mota"
-__license__ = "Apache 2.0"
-
-
 from .utils import seq  # NoQA

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -20,8 +20,7 @@ from uuid import UUID
 
 from django.core.files.base import ContentFile
 from django.db.models import Field, Model
-
-from .timezone import now
+from django.utils.timezone import now
 
 MAX_LENGTH = 300
 # Using sys.maxint here breaks a bunch of tests when running against a

--- a/model_bakery/timezone.py
+++ b/model_bakery/timezone.py
@@ -6,13 +6,8 @@ https://docs.djangoproject.com/en/1.4/topics/i18n/timezones/
 
 from datetime import datetime
 
-try:
-    from django.conf import settings
-    from django.utils.timezone import now, utc
-except ImportError:
-
-    def now():
-        return datetime.now()
+from django.conf import settings
+from django.utils.timezone import utc
 
 
 def smart_datetime(*args) -> datetime:

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,22 @@
-from os.path import dirname, join
+from os.path import abspath, dirname, join
 
 import setuptools
 
-import model_bakery
+about: dict = {}
+here = abspath(dirname(__file__))
+with open(join(here, "model_bakery", "__about__.py")) as f:  # type: ignore
+    exec(f.read(), about)
 
 setuptools.setup(
     name="model_bakery",
-    version=model_bakery.__version__,
+    version=about["__version__"],
+    author=about["__author__"],
+    author_email=about["__email__"],
+    url=about["__url__"],
+    license=about["__license__"],
     packages=["model_bakery"],
     include_package_data=True,  # declarations in MANIFEST.in
-    install_requires=open(join(dirname(__file__), "requirements.txt")).readlines(),
-    author="berinfontes",
-    author_email="bernardoxhc@gmail.com",
-    url="http://github.com/model-bakers/model_bakery",
-    license="Apache 2.0",
+    install_requires=open(join(here, "requirements.txt")).readlines(),
     description="Smart object creation facility for Django.",
     long_description=open(join(dirname(__file__), "README.md")).read(),
     long_description_content_type="text/markdown",

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -2,8 +2,9 @@
 from datetime import timedelta
 from decimal import Decimal
 
+from django.utils.timezone import now
+
 from model_bakery.recipe import Recipe, foreign_key, related, seq
-from model_bakery.timezone import now
 from tests.generic.models import (
     TEST_TIME,
     Dog,

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -5,11 +5,12 @@ from random import choice  # noqa
 from unittest.mock import patch
 
 import pytest
+from django.utils.timezone import now
 
 from model_bakery import baker
 from model_bakery.exceptions import InvalidQuantityException, RecipeIteratorEmpty
 from model_bakery.recipe import Recipe, RecipeForeignKey, foreign_key
-from model_bakery.timezone import now, tz_aware
+from model_bakery.timezone import tz_aware
 from tests.generic.baker_recipes import SmallDogRecipe, pug
 from tests.generic.models import (
     TEST_TIME,

--- a/tox.ini
+++ b/tox.ini
@@ -51,4 +51,4 @@ commands=black . --check
 [testenv:mypy]
 deps=mypy
 basepython=python3
-commands=python -m mypy .
+commands=python -m mypy model_bakery


### PR DESCRIPTION
I decided to do smaller steps to tackle #35 :)
It should be simpler to review-iterate now.


P.S. I wonder if this should be considered as a breaking change, but I doubt anyone who switched to `model_bakery` was using Django 1.4 and was importing this method.


P.P.S. Tests did fail due to the `setup.py` import issue. I put a separate PR for them: https://github.com/model-bakers/model_bakery/pull/142 and rebased this one on top of that branch. So the only meaningful here is the first commit: 2ec3eacc1a22b25d10034dc3f46b81377f3d384d. To simplify review, I changed base branch to `about`, which will be switched to `main` automatically after #142 would be merged.