### PR TITLE
Modify `setup.py` to not import the whole module for package data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Type hinting fixed for Recipe "_model" parameter
+- Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`
 
 ### Removed
 

--- a/model_bakery/__about__.py
+++ b/model_bakery/__about__.py
@@ -1,0 +1,5 @@
+__version__ = "1.2.1"
+__author__ = "berinfontes"
+__email__ = "bernardoxhc@gmail.com"
+__url__ = "https://github.com/model-bakers/model_bakery"
+__license__ = "Apache 2.0"

--- a/model_bakery/__init__.py
+++ b/model_bakery/__init__.py
@@ -1,8 +1,1 @@
-"""Model Bakery module configuration."""
-__version__ = "1.2.1"
-__title__ = "model_bakery"
-__author__ = "Vanderson Mota"
-__license__ = "Apache 2.0"
-
-
 from .utils import seq  # NoQA

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -6,12 +6,7 @@ import warnings
 from types import ModuleType
 from typing import Any, Callable, Optional, Union
 
-try:
-    from django.apps import apps
-except ModuleNotFoundError:
-    # probably we are importing this module from setup.py, before installing
-    # the requirements (and we don't need Django at this point)
-    apps = None
+from django.apps import apps
 
 from .timezone import tz_aware
 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,22 @@
-from os.path import dirname, join
+from os.path import abspath, dirname, join
 
 import setuptools
 
-import model_bakery
+about: dict = {}
+here = abspath(dirname(__file__))
+with open(join(here, "model_bakery", "__about__.py")) as f:  # type: ignore
+    exec(f.read(), about)
 
 setuptools.setup(
     name="model_bakery",
-    version=model_bakery.__version__,
+    version=about["__version__"],
+    author=about["__author__"],
+    author_email=about["__email__"],
+    url=about["__url__"],
+    license=about["__license__"],
     packages=["model_bakery"],
     include_package_data=True,  # declarations in MANIFEST.in
-    install_requires=open(join(dirname(__file__), "requirements.txt")).readlines(),
-    author="berinfontes",
-    author_email="bernardoxhc@gmail.com",
-    url="http://github.com/model-bakers/model_bakery",
-    license="Apache 2.0",
+    install_requires=open(join(here, "requirements.txt")).readlines(),
     description="Smart object creation facility for Django.",
     long_description=open(join(dirname(__file__), "README.md")).read(),
     long_description_content_type="text/markdown",

--- a/tox.ini
+++ b/tox.ini
@@ -51,4 +51,4 @@ commands=black . --check
 [testenv:mypy]
 deps=mypy
 basepython=python3
-commands=python -m mypy .
+commands=python -m mypy model_bakery


### PR DESCRIPTION
While working on #141 I found out that we are importing the whole `model_bakery` lib just in order to obtain `__version__`.
And due to the change in imports, tox starts to fail.

```
Run python -m tox
GLOB sdist-make: /home/runner/work/model_bakery/model_bakery/setup.py
ERROR: invocation failed (exit code 1), logfile: /home/runner/work/model_bakery/model_bakery/.tox/log/GLOB-0.log
================================== log start ===================================
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import model_bakery
  File "/home/runner/work/model_bakery/model_bakery/model_bakery/__init__.py", line 8, in <module>
    from .utils import seq  # NoQA
  File "/home/runner/work/model_bakery/model_bakery/model_bakery/utils.py", line 16, in <module>
    from .timezone import tz_aware
  File "/home/runner/work/model_bakery/model_bakery/model_bakery/timezone.py", line 9, in <module>
    from django.conf import settings
ModuleNotFoundError: No module named 'django'

=================================== log end ====================================
ERROR: FAIL could not package project - v = InvocationError('/opt/hostedtoolcache/Python/3.8.7/x64/bin/python setup.py sdist --formats=zip --dist-dir /home/runner/work/model_bakery/model_bakery/.tox/dist', 1)
```

I decided to move some bits around and put stuff in a separate `__about__.py`, which would be read by `setup.py`.
This structure works quite fine in my other packages. 
What do you think? I am happy to use a different approach, the only thing is important that we should not import lib for nothing. :)