### PR TITLE
Timezone module cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
 - Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/140)
 - Add the functionality to import recipes using `app_name.recipe_name`
+- [dev] Add a unit test for `utils.seq`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add new `_bulk_create` parameter to `make` for using Django manager `bulk_create` with `_quantity` [PR #134](https://github.com/model-bakers/model_bakery/pull/134)
 - Add the functionality to import Django models using the `app_name.ModelName` convention in `import_from_str` [PR #140](https://github.com/model-bakers/model_bakery/pull/140)
-- Add the functionality to import recipes using `app_name.recipe_name`
-- [dev] Add a unit test for `utils.seq`
+- Add the functionality to import recipes using `app_name.recipe_name` [PR #140](https://github.com/model-bakers/model_bakery/pull/140)
+- [dev] Add a unit test for `utils.seq` [PR #143](https://github.com/model-bakers/model_bakery/pull/143)
 
 ### Changed
 
-- Type hinting fixed for Recipe "_model" parameter
-- Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`
+- Type hinting fixed for Recipe "_model" parameter  [PR #124](https://github.com/model-bakers/model_bakery/pull/124)
+- Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`  [PR #142](https://github.com/model-bakers/model_bakery/pull/142)
 
 ### Removed
-- `model_bakery.timezone.now` fallback (use `django.utils.timezone.now` instead)
+- `model_bakery.timezone.now` fallback (use `django.utils.timezone.now` instead)  [PR #141](https://github.com/model-bakers/model_bakery/pull/141)
+- `model_bakery.timezone.smart_datetime` function (directly use `model_bakery.timezone.tz_aware` instead)  [PR #147](https://github.com/model-bakers/model_bakery/pull/147)
 
 
 ## [1.2.1](https://pypi.org/project/model-bakery/1.2.1/)
@@ -28,15 +29,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add ability to pass `str` values to `foreign_key` for recipes from other modules [PR #120](https://github.com/model-bakers/model_bakery/pull/120)
 - Add new parameter `_using` to support multi database Django applications [PR #126](https://github.com/model-bakers/model_bakery/pull/126)
-- [dev] Add instructions and script for running `postgres` and `postgis` tests.
+- [dev] Add instructions and script for running `postgres` and `postgis` tests. [PR #118](https://github.com/model-bakers/model_bakery/pull/118)
 
 ### Changed
 - Fixed _model parameter annotations [PR #115](https://github.com/model-bakers/model_bakery/pull/115)
 - Fixes bug when field has callable `default` [PR #117](https://github.com/model-bakers/model_bakery/pull/117)
 
 ### Removed
-- [dev] Drop Python 3.5 support as it is retired (https://www.python.org/downloads/release/python-3510/)
-- [dev] Remove support for Django<2.2 ([more about Django supported versions](https://www.djangoproject.com/download/#supported-versions))
+- [dev] Drop Python 3.5 support as it is retired (https://www.python.org/downloads/release/python-3510/) [PR #119](https://github.com/model-bakers/model_bakery/pull/119)
+- [dev] Remove support for Django<2.2 ([more about Django supported versions](https://www.djangoproject.com/download/#supported-versions)) [PR #126](https://github.com/model-bakers/model_bakery/pull/126)
 
 ## [1.2.0](https://pypi.org/project/model-bakery/1.2.0/)
 

--- a/model_bakery/timezone.py
+++ b/model_bakery/timezone.py
@@ -1,8 +1,4 @@
-"""Add support for Django 1.4+ safe datetimes.
-
-https://docs.djangoproject.com/en/1.4/topics/i18n/timezones/
-"""
-# TODO: the whole file seems to be not needed anymore, since Django has this tooling built-in
+"""Utility functions to manage timezone code."""
 
 from datetime import datetime
 
@@ -10,14 +6,9 @@ from django.conf import settings
 from django.utils.timezone import utc
 
 
-def smart_datetime(*args) -> datetime:
-    value = datetime(*args)
-    return tz_aware(value)
-
-
-def tz_aware(d: datetime) -> datetime:
-    value = d
+def tz_aware(value: datetime) -> datetime:
+    """Return an UTC-aware datetime in case of USE_TZ=True."""
     if settings.USE_TZ:
-        value = d.replace(tzinfo=utc)
+        value = value.replace(tzinfo=utc)
 
     return value

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -2,7 +2,7 @@
 # TESTING PURPOSE ONLY MODELS!!       #
 # DO NOT ADD THE APP TO INSTALLED_APPS#
 #######################################
-import datetime as base_datetime
+import datetime
 from decimal import Decimal
 from tempfile import gettempdir
 
@@ -13,7 +13,7 @@ from django.core.files.storage import FileSystemStorage
 from django.utils.timezone import now
 
 from model_bakery.gis import BAKER_GIS
-from model_bakery.timezone import smart_datetime as datetime
+from model_bakery.timezone import tz_aware
 
 from .fields import (
     CustomFieldViaSettings,
@@ -47,7 +47,7 @@ OCCUPATION_CHOICES = (
     ("Education", (("teacher", "Teacher"), ("principal", "Principal"))),
 )
 
-TEST_TIME = base_datetime.datetime(2014, 7, 21, 15, 39, 58, 457698)
+TEST_TIME = datetime.datetime(2014, 7, 21, 15, 39, 58, 457698)
 
 
 class ModelWithImpostorField(models.Model):
@@ -277,7 +277,9 @@ class DummyDefaultFieldsModel(models.Model):
     default_int_field = models.IntegerField(default=123)
     default_float_field = models.FloatField(default=123.0)
     default_date_field = models.DateField(default="2012-01-01")
-    default_date_time_field = models.DateTimeField(default=datetime(2012, 1, 1))
+    default_date_time_field = models.DateTimeField(
+        default=tz_aware(datetime.datetime(2012, 1, 1))
+    )
     default_time_field = models.TimeField(default="00:00:00")
     default_decimal_field = models.DecimalField(
         max_digits=5, decimal_places=2, default=Decimal("0")

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -17,7 +17,7 @@ from model_bakery.exceptions import (
     InvalidQuantityException,
     ModelNotFound,
 )
-from model_bakery.timezone import smart_datetime
+from model_bakery.timezone import tz_aware
 from tests.generic import models
 from tests.generic.forms import DummyGenericIPAddressFieldForm
 
@@ -52,7 +52,7 @@ class QueryCount:
 
     def __call__(self, execute, sql, params, many, context):
         """
-        `django.db.connection.execute_wrapper` callback
+        `django.db.connection.execute_wrapper` callback.
 
         https://docs.djangoproject.com/en/3.1/topics/db/instrumentation/
         """
@@ -60,10 +60,7 @@ class QueryCount:
         execute(sql, params, many, context)
 
     def start_count(self):
-        """
-        Reset query count to 0 and return context manager for wrapping db
-        queries.
-        """
+        """Reset query count to 0 and return context manager for wrapping db queries."""
         self.count = 0
 
         return connection.execute_wrapper(self)
@@ -654,7 +651,7 @@ class TestSkipDefaultsTestCase:
         assert dummy.default_int_field == 123
         assert dummy.default_float_field == 123.0
         assert dummy.default_date_field == "2012-01-01"
-        assert dummy.default_date_time_field == smart_datetime(2012, 1, 1)
+        assert dummy.default_date_time_field == tz_aware(datetime.datetime(2012, 1, 1))
         assert dummy.default_time_field == "00:00:00"
         assert dummy.default_decimal_field == Decimal("0")
         assert dummy.default_email_field == "foo@bar.org"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from inspect import getmodule
 
 import pytest
+from django.utils.timezone import utc
 
 from model_bakery.utils import get_calling_module, import_from_str, seq
 from tests.generic.models import User
@@ -143,11 +144,21 @@ class TestSeq:
         assert next(sequence) == datetime.time(17, 37, 58, 457698)
         assert next(sequence) == datetime.time(18, 36, 58, 457698)
 
-    def test_datetime(self):
+    @pytest.mark.parametrize("use_tz", [False, True])
+    def test_datetime(self, settings, use_tz):
+        settings.USE_TZ = use_tz
+        tzinfo = utc if use_tz else None
+
         sequence = seq(
             datetime.datetime(2021, 2, 11, 15, 39, 58, 457698),
             increment_by=datetime.timedelta(hours=3),
         )
-        assert next(sequence) == datetime.datetime(2021, 2, 11, 18, 39, 58, 457698)
-        assert next(sequence) == datetime.datetime(2021, 2, 11, 21, 39, 58, 457698)
-        assert next(sequence) == datetime.datetime(2021, 2, 12, 00, 39, 58, 457698)
+        assert next(sequence) == datetime.datetime(
+            2021, 2, 11, 18, 39, 58, 457698
+        ).replace(tzinfo=tzinfo)
+        assert next(sequence) == datetime.datetime(
+            2021, 2, 11, 21, 39, 58, 457698
+        ).replace(tzinfo=tzinfo)
+        assert next(sequence) == datetime.datetime(
+            2021, 2, 12, 00, 39, 58, 457698
+        ).replace(tzinfo=tzinfo)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
+import datetime
+from decimal import Decimal
 from inspect import getmodule
 
 import pytest
 
-from model_bakery.utils import get_calling_module, import_from_str
+from model_bakery.utils import get_calling_module, import_from_str, seq
 from tests.generic.models import User
 
 
@@ -45,3 +47,107 @@ def test_get_calling_module():
     # Raise an `IndexError` when attempting to access too many frames removed
     with pytest.raises(IndexError):
         assert get_calling_module(100)
+
+
+class TestSeq:
+    def test_string(self):
+        sequence = seq("muffin")
+        assert next(sequence) == "muffin1"
+        assert next(sequence) == "muffin2"
+        assert next(sequence) == "muffin3"
+
+    def test_string_start(self):
+        sequence = seq("muffin", start=9)
+        assert next(sequence) == "muffin9"
+        assert next(sequence) == "muffin10"
+        assert next(sequence) == "muffin11"
+
+    def test_string_suffix(self):
+        sequence = seq("cookie", suffix="@example.com")
+        assert next(sequence) == "cookie1@example.com"
+        assert next(sequence) == "cookie2@example.com"
+        assert next(sequence) == "cookie3@example.com"
+
+    def test_string_suffix_and_start(self):
+        sequence = seq("cookie", start=111, suffix="@example.com")
+        assert next(sequence) == "cookie111@example.com"
+        assert next(sequence) == "cookie112@example.com"
+        assert next(sequence) == "cookie113@example.com"
+
+    def test_string_invalid_suffix(self):
+        sequence = seq("cookie", suffix=42)
+
+        with pytest.raises(TypeError) as exc:
+            next(sequence)
+            assert str(exc.value) == "Sequences suffix can only be a string"
+
+    def test_int(self):
+        sequence = seq(1)
+        assert next(sequence) == 2
+        assert next(sequence) == 3
+        assert next(sequence) == 4
+
+    def test_int_increment_by(self):
+        sequence = seq(1, increment_by=3)
+        assert next(sequence) == 4
+        assert next(sequence) == 7
+        assert next(sequence) == 10
+
+    def test_decimal(self):
+        sequence = seq(Decimal("36.6"))
+        assert next(sequence) == Decimal("37.6")
+        assert next(sequence) == Decimal("38.6")
+        assert next(sequence) == Decimal("39.6")
+
+    def test_decimal_increment_by(self):
+        sequence = seq(Decimal("36.6"), increment_by=Decimal("2.4"))
+        assert next(sequence) == Decimal("39.0")
+        assert next(sequence) == Decimal("41.4")
+        assert next(sequence) == Decimal("43.8")
+
+    def test_float(self):
+        sequence = seq(1.23)
+        assert next(sequence) == 2.23
+        assert next(sequence) == 3.23
+        assert next(sequence) == 4.23
+
+    def test_float_increment_by(self):
+        sequence = seq(1.23, increment_by=1.8)
+        assert next(sequence) == pytest.approx(3.03)
+        assert next(sequence) == pytest.approx(4.83)
+        assert next(sequence) == pytest.approx(6.63)
+
+    def test_numbers_with_suffix(self):
+        sequence = seq(1, suffix="iamnotanumber")
+        with pytest.raises(TypeError) as exc:
+            next(sequence)
+            assert (
+                str(exc.value)
+                == "Sequences with suffix can only be used with text values"
+            )
+
+    def test_date(self):
+        sequence = seq(
+            datetime.date(2021, 2, 11), increment_by=datetime.timedelta(days=6)
+        )
+        assert next(sequence) == datetime.date(2021, 2, 17)
+        assert next(sequence) == datetime.date(2021, 2, 23)
+        assert next(sequence) == datetime.date(2021, 3, 1)
+
+    def test_time(self):
+        sequence = seq(
+            datetime.time(15, 39, 58, 457698),
+            increment_by=datetime.timedelta(minutes=59),
+        )
+        assert next(sequence) == datetime.time(16, 38, 58, 457698)
+        assert next(sequence) == datetime.time(17, 37, 58, 457698)
+        assert next(sequence) == datetime.time(18, 36, 58, 457698)
+
+    def test_datetime(self):
+        sequence = seq(
+            datetime.datetime(2021, 2, 11, 15, 39, 58, 457698),
+            increment_by=datetime.timedelta(hours=3),
+        )
+        assert next(sequence) == datetime.datetime(2021, 2, 11, 18, 39, 58, 457698)
+        assert next(sequence) == datetime.datetime(2021, 2, 11, 21, 39, 58, 457698)
+        assert next(sequence) == datetime.datetime(2021, 2, 12, 00, 39, 58, 457698)


### PR DESCRIPTION
- remove `smart_datetime` (replaced by direct `tz_aware` use)
- update module docstrings, remove TODO comment

Current base is `test_seq` to be sure `seq` functions as before.