### PR TITLE
Add py.typed export per PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     license=about["__license__"],
     packages=["model_bakery"],
     include_package_data=True,  # declarations in MANIFEST.in
+    package_data={"model_bakery": ["py.typed"]},
     install_requires=open(join(here, "requirements.txt")).readlines(),
     description="Smart object creation facility for Django.",
     long_description=open(join(dirname(__file__), "README.md")).read(),


### PR DESCRIPTION
Add `py.typed` file and export type annotations per [PEP 561](https://www.python.org/dev/peps/pep-0561/) so that type testing tools like mypy can actually verify types when using `model_bakery`.

No new test added for this change and I don't think there's any documentation necessary but let me know if something needs to be added.
