### PR TITLE
Update Dependabot config file to support GH Actions and auto-rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+rebase-strategy: "auto"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Type hinting fixed for Recipe "_model" parameter  [PR #124](https://github.com/model-bakers/model_bakery/pull/124)
 - Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`  [PR #142](https://github.com/model-bakers/model_bakery/pull/142)
 - [dev] Add Dependabot config file [PR #146](https://github.com/model-bakers/model_bakery/pull/146)
+- [dev] Update Dependabot config file to support GH Actions and auto-rebase [PR #160](https://github.com/model-bakers/model_bakery/pull/160)
 
 ### Removed
 - `model_bakery.timezone.now` fallback (use `django.utils.timezone.now` instead)  [PR #141](https://github.com/model-bakers/model_bakery/pull/141)


### PR DESCRIPTION
- Monitor GitHub Actions package ecosystem
- Auto-rebase dependabot PRs in case of conflicts with `main` branch

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates