### PR TITLE
Fix creation of model instances with related model fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Type hinting fixed for Recipe "_model" parameter  [PR #124](https://github.com/model-bakers/model_bakery/pull/124)
-- Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`  [PR #142](https://github.com/model-bakers/model_bakery/pull/142)
+- Fixed a bug (introduced in 1.2.1) that was breaking creation of model instances with related model fields [PR #164](https://github.com/model-bakers/model_bakery/pull/164)
+- [dev] Modify `setup.py` to not import the whole module for package data, but get it from `__about__.py`  [PR #142](https://github.com/model-bakers/model_bakery/pull/142)
 - [dev] Add Dependabot config file [PR #146](https://github.com/model-bakers/model_bakery/pull/146)
 
 ### Removed

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -349,23 +349,7 @@ class Baker(object):
                     self.m2m_dict[field.name] = self.m2m_value(field)
                 else:
                     self.m2m_dict[field.name] = self.model_attrs.pop(field.name)
-
             elif field.name not in self.model_attrs:
-                # TODO: this might be a code going into a wrong direction, drop it if
-                #  things in `model_bakery.baker.Baker.generate_value` will work out
-                # if (
-                #     isinstance(field, ForeignKey)
-                #     and "{0}_id".format(field.name) not in self.model_attrs
-                # ):
-                #     value = self.generate_value(field, commit_related)
-                #     if isinstance(value, field.related_model):
-                #         field_name = field.name
-                #     else:
-                #         field_name = "{0}_id".format(field.name)
-                #
-                #     self.model_attrs[field_name] = value
-                #
-                # elif (
                 if (
                     not isinstance(field, ForeignKey)
                     or "{0}_id".format(field.name) not in self.model_attrs
@@ -547,10 +531,11 @@ class Baker(object):
         """Call the associated generator with a field passing all required args.
 
         Generator Resolution Precedence Order:
-        -- attr_mapping - mapping per attribute name
-        -- choices -- mapping from avaiable field choices
-        -- type_mapping - mapping from user defined type associated generators
-        -- default_mapping - mapping from pre-defined type associated
+        -- `field.default` - model field default value, unless explicitly overwritten during baking
+        -- `attr_mapping` - mapping per attribute name
+        -- `choices` -- mapping from available field choices
+        -- `type_mapping` - mapping from user defined type associated generators
+        -- `default_mapping` - mapping from pre-defined type associated
            generators
 
         `attr_mapping` and `type_mapping` can be defined easily overwriting the
@@ -559,7 +544,7 @@ class Baker(object):
         is_content_type_fk = isinstance(field, ForeignKey) and issubclass(
             self._remote_field(field).model, contenttypes.models.ContentType
         )
-        # when a default provided, we only use it unless the field is listed in `self.rel_fields`
+        # we only use default unless the field is overwritten in `self.rel_fields`
         if field.has_default() and field.name not in self.rel_fields:
             if callable(field.default):
                 return field.default()

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -349,8 +349,21 @@ class Baker(object):
                     self.m2m_dict[field.name] = self.m2m_value(field)
                 else:
                     self.m2m_dict[field.name] = self.model_attrs.pop(field.name)
+
             elif field.name not in self.model_attrs:
                 if (
+                    isinstance(field, ForeignKey)
+                    and "{0}_id".format(field.name) not in self.model_attrs
+                ):
+                    value = self.generate_value(field, commit_related)
+                    if isinstance(value, field.related_model):
+                        field_name = field.name
+                    else:
+                        field_name = "{0}_id".format(field.name)
+
+                    self.model_attrs[field_name] = value
+
+                elif (
                     not isinstance(field, ForeignKey)
                     or "{0}_id".format(field.name) not in self.model_attrs
                 ):

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -351,19 +351,22 @@ class Baker(object):
                     self.m2m_dict[field.name] = self.model_attrs.pop(field.name)
 
             elif field.name not in self.model_attrs:
+                # TODO: this might be a code going into a wrong direction, drop it if
+                #  things in `model_bakery.baker.Baker.generate_value` will work out
+                # if (
+                #     isinstance(field, ForeignKey)
+                #     and "{0}_id".format(field.name) not in self.model_attrs
+                # ):
+                #     value = self.generate_value(field, commit_related)
+                #     if isinstance(value, field.related_model):
+                #         field_name = field.name
+                #     else:
+                #         field_name = "{0}_id".format(field.name)
+                #
+                #     self.model_attrs[field_name] = value
+                #
+                # elif (
                 if (
-                    isinstance(field, ForeignKey)
-                    and "{0}_id".format(field.name) not in self.model_attrs
-                ):
-                    value = self.generate_value(field, commit_related)
-                    if isinstance(value, field.related_model):
-                        field_name = field.name
-                    else:
-                        field_name = "{0}_id".format(field.name)
-
-                    self.model_attrs[field_name] = value
-
-                elif (
                     not isinstance(field, ForeignKey)
                     or "{0}_id".format(field.name) not in self.model_attrs
                 ):
@@ -556,8 +559,8 @@ class Baker(object):
         is_content_type_fk = isinstance(field, ForeignKey) and issubclass(
             self._remote_field(field).model, contenttypes.models.ContentType
         )
-
-        if field.has_default():
+        # when a default provided, we only use it unless the field is listed in `self.rel_fields`
+        if field.has_default() and field.name not in self.rel_fields:
             if callable(field.default):
                 return field.default()
             return field.default

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -271,6 +271,15 @@ class DummyForeignKeyWithDefaultIdModel(models.Model):
     )
 
 
+class DummyOptionalForeignKey(models.Model):
+    named_thing = models.ForeignKey(
+        "NamedThing",
+        null=True,
+        default=None,
+        on_delete=models.SET_NULL,
+    )
+
+
 class DummyNullFieldsModel(models.Model):
     null_foreign_key = models.ForeignKey(
         "DummyBlankFieldsModel", null=True, on_delete=models.CASCADE

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -254,6 +254,23 @@ class DummyGenericRelationModel(models.Model):
     relation = GenericRelation(DummyGenericForeignKeyModel)
 
 
+class NamedThing(models.Model):
+    name = models.CharField(max_length=64)
+
+
+def get_default_namedthing_id():
+    instance, _ = NamedThing.objects.get_or_create(name="Default")
+    return instance.id
+
+
+class DummyForeignKeyWithDefaultIdModel(models.Model):
+    named_thing = models.ForeignKey(
+        "NamedThing",
+        default=get_default_namedthing_id,
+        on_delete=models.SET_DEFAULT,
+    )
+
+
 class DummyNullFieldsModel(models.Model):
     null_foreign_key = models.ForeignKey(
         "DummyBlankFieldsModel", null=True, on_delete=models.CASCADE

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -181,6 +181,10 @@ class LonelyPerson(models.Model):
     only_friend = models.OneToOneField(Person, on_delete=models.CASCADE)
 
 
+class Cake(models.Model):
+    name = models.CharField(max_length=64)
+
+
 class RelatedNamesModel(models.Model):
     name = models.CharField(max_length=256)
     one_to_one = models.OneToOneField(
@@ -188,6 +192,30 @@ class RelatedNamesModel(models.Model):
     )
     foreign_key = models.ForeignKey(
         Person, related_name="fk_related", on_delete=models.CASCADE
+    )
+
+
+def get_default_cake_id():
+    instance, _ = Cake.objects.get_or_create(name="Muffin")
+    return instance.id
+
+
+class RelatedNamesWithDefaultsModel(models.Model):
+    name = models.CharField(max_length=256, default="Bravo")
+    cake = models.ForeignKey(
+        Cake,
+        on_delete=models.CASCADE,
+        default=get_default_cake_id,
+    )
+
+
+class RelatedNamesWithEmptyDefaultsModel(models.Model):
+    name = models.CharField(max_length=256, default="Bravo")
+    cake = models.ForeignKey(
+        Cake,
+        on_delete=models.CASCADE,
+        null=True,
+        default=None,
     )
 
 
@@ -252,32 +280,6 @@ class DummyGenericForeignKeyModel(models.Model):
 
 class DummyGenericRelationModel(models.Model):
     relation = GenericRelation(DummyGenericForeignKeyModel)
-
-
-class NamedThing(models.Model):
-    name = models.CharField(max_length=64)
-
-
-def get_default_namedthing_id():
-    instance, _ = NamedThing.objects.get_or_create(name="Default")
-    return instance.id
-
-
-class DummyForeignKeyWithDefaultIdModel(models.Model):
-    named_thing = models.ForeignKey(
-        "NamedThing",
-        default=get_default_namedthing_id,
-        on_delete=models.SET_DEFAULT,
-    )
-
-
-class DummyOptionalForeignKey(models.Model):
-    named_thing = models.ForeignKey(
-        "NamedThing",
-        null=True,
-        default=None,
-        on_delete=models.SET_NULL,
-    )
 
 
 class DummyNullFieldsModel(models.Model):

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -279,24 +279,32 @@ class TestFillingGenericForeignKeyField:
 @pytest.mark.django_db
 class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
     def test_filling_foreignkey_with_default_id(self):
-        dummy = baker.make(models.DummyForeignKeyWithDefaultIdModel)
-        assert dummy.named_thing.id == models.get_default_namedthing_id()
-        assert dummy.named_thing.name == "Default"
+        dummy = baker.make(models.RelatedNamesWithDefaultsModel)
+        assert dummy.cake.__class__.objects.count() == 1
+        assert dummy.cake.id == models.get_default_cake_id()
+        assert dummy.cake.name == "Muffin"
 
     def test_filling_foreignkey_with_default_id_with_custom_arguments(self):
         dummy = baker.make(
-            models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Not default"
+            models.RelatedNamesWithDefaultsModel, cake__name="Baumkuchen"
         )
-        assert dummy.named_thing.__class__.objects.count() == 1
-        assert dummy.named_thing.id == dummy.named_thing.__class__.objects.get().id
-        assert dummy.named_thing.name == "Not default"
+        assert dummy.cake.__class__.objects.count() == 1
+        assert dummy.cake.id == dummy.cake.__class__.objects.get().id
+        assert dummy.cake.name == "Baumkuchen"
 
 
 @pytest.mark.django_db
 class TestFillingOptionalForeignKeyField:
+    def test_not_filling_optional_foreignkey(self):
+        dummy = baker.make(models.RelatedNamesWithEmptyDefaultsModel)
+        assert dummy.cake is None
+
     def test_filling_optional_foreignkey_implicitly(self):
-        dummy = baker.make(models.DummyOptionalForeignKey, named_thing__name="Optional")
-        assert dummy.named_thing.name == "Optional"
+        dummy = baker.make(
+            models.RelatedNamesWithEmptyDefaultsModel, cake__name="Carrot cake"
+        )
+        assert dummy.cake.__class__.objects.count() == 1
+        assert dummy.cake.name == "Carrot cake"
 
 
 @pytest.mark.django_db

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -277,6 +277,15 @@ class TestFillingGenericForeignKeyField:
 
 
 @pytest.mark.django_db
+class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
+    def test_filling_foreignkey_with_default_id(self):
+        dummy = baker.make(
+            models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default"
+        )
+        assert dummy.named_thing.id == models.get_default_namedthing_id()
+
+
+@pytest.mark.django_db
 class TestsFillingFileField:
     def test_filling_file_field(self):
         dummy = baker.make(models.DummyFileFieldModel, _create_files=True)

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -279,10 +279,24 @@ class TestFillingGenericForeignKeyField:
 @pytest.mark.django_db
 class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:
     def test_filling_foreignkey_with_default_id(self):
-        dummy = baker.make(
-            models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Default"
-        )
+        dummy = baker.make(models.DummyForeignKeyWithDefaultIdModel)
         assert dummy.named_thing.id == models.get_default_namedthing_id()
+        assert dummy.named_thing.name == "Default"
+
+    def test_filling_foreignkey_with_default_id_with_custom_arguments(self):
+        dummy = baker.make(
+            models.DummyForeignKeyWithDefaultIdModel, named_thing__name="Not default"
+        )
+        assert dummy.named_thing.__class__.objects.count() == 1
+        assert dummy.named_thing.id == dummy.named_thing.__class__.objects.get().id
+        assert dummy.named_thing.name == "Not default"
+
+
+@pytest.mark.django_db
+class TestFillingOptionalForeignKeyField:
+    def test_filling_optional_foreignkey_implicitly(self):
+        dummy = baker.make(models.DummyOptionalForeignKey, named_thing__name="Optional")
+        assert dummy.named_thing.name == "Optional"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
https://github.com/model-bakers/model_bakery/pull/117 introduced an issue for two cases :
- where `id` value is provided as default for foreign key
- where foreign key is defaulting to `None`, but we overwrite this default by some value

See discussion in #136 that led to a current solution (first fix attempt was different, see 035281c0b07f88bfdac8375460f41495070cc7de).

This PR attempts to fix that issue by checking if the field has a default AND not overwritten in `self.rel_fields`.
I've added test cases, kindly suggested by @cb109 in #136.