### PR TITLE
Allows _quantity use on recipes containing OneToOne fields (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add the functionality to import recipes using `app_name.recipe_name` [PR #140](https://github.com/model-bakers/model_bakery/pull/140)
 - [dev] Add a unit test for `utils.seq` [PR #143](https://github.com/model-bakers/model_bakery/pull/143)
 - [dev] Run CI against `main` Django branch to cover possible upcoming changes/deprecations [PR #159](https://github.com/model-bakers/model_bakery/pull/159)
+- Add new `one_to_one` parameter to `foreign_key` to allow usage of `_quantity` for recipes based on models with OneToOne fields [PR #169](https://github.com/model-bakers/model_bakery/pull/169)
 
 ### Changed
 

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -159,6 +159,31 @@ If you want to set m2m relationship you can use ``related`` as well:
         products=related(pencil, pen)
     )
 
+When creating models based on a ``foreign_key`` recipe using the ``_quantity`` argument, only one related model will be created for all new instances.
+
+.. code-block:: python
+    from model_baker.recipe import foreign_key, Recipe
+
+    person = Recipe(Person, name='Albert')
+    dog = Recipe(Dog, owner=foreign_key(person))
+
+    # All dogs share the same owner
+    dogs = dog.make_recipe(_quantity=2)
+    assert dogs[0].owner.id == dogs[1].owner.id
+
+This will cause an issue if your models use ``OneToOneField``. In that case, you can provide ``one_to_one=True`` to the recipe to make sure every instance created by ``_quantity`` has a unique id.
+
+.. code-block:: python
+    from model_baker.recipe import foreign_key, Recipe
+
+    person = Recipe(Person, name='Albert')
+    dog = Recipe(Dog, owner=foreign_key(person, one_to_one=True))
+
+    # Each dog has a unique owner
+    dogs = dog.make_recipe(_quantity=2)
+    assert dogs[0].owner.id != dogs[1].owner.id
+
+
 
 Recipes with callables
 ----------------------

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -51,10 +51,10 @@ class Recipe(object):
                 if _save_related:
                     # Create a unique foreign key for each quantity if one_to_one required
                     if v.one_to_one is True:
-                        seq = []
+                        rel_gen = []
                         for i in range(_quantity):
-                            seq.append(v.recipe.make(_using=_using, **recipe_attrs))
-                        mapping[k] = itertools.cycle(seq)
+                            rel_gen.append(v.recipe.make(_using=_using, **recipe_attrs))
+                        mapping[k] = itertools.cycle(rel_gen)
                     # Otherwise create shared foreign key for each quantity
                     else:
                         mapping[k] = v.recipe.make(_using=_using, **recipe_attrs)

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -11,6 +11,7 @@ from tests.generic.models import (
     DummyDefaultFieldsModel,
     DummyUniqueIntegerFieldModel,
     Person,
+    LonelyPerson,
     School,
 )
 
@@ -26,6 +27,8 @@ person = Recipe(
     appointment=now(),
     birth_time=now(),
 )
+
+lonely_person = Recipe(LonelyPerson, only_friend=foreign_key(person, one_to_one=True))
 
 serial_person = Recipe(
     Person,

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -407,6 +407,11 @@ class TestForeignKey:
         movie = baker.make_recipe("tests.generic.movie_with_cast")
         assert movie.cast_members.count() == 2
 
+    def test_one_to_one_relationship(self):
+        lonely_people = baker.make_recipe("tests.generic.lonely_person", _quantity=2)
+        friend_ids = set([x.only_friend.id for x in lonely_people])
+        assert len(friend_ids) == 2
+
 
 @pytest.mark.django_db
 class TestM2MField:


### PR DESCRIPTION
Fixes #145 by adding an `one_to_one` argument to `foreign_key` and documents the behaviour.

When `one_to_one=True`, the `make_recipe` function will create an unique related model for each `_quantity`. This is False by default so the behaviour where only one related model is created remains the default.

Thanks for all the 🍰 😄 