### PR TITLE
Add explanations to imports in `generators.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `model_bakery.timezone.smart_datetime` function (directly use `model_bakery.timezone.tz_aware` instead)  [PR #147](https://github.com/model-bakers/model_bakery/pull/147)
 - Remove all signs of Django 1.11 (as we dropped it in 1.2.1) [PR #157](https://github.com/model-bakers/model_bakery/pull/157)
 - Drop unsupported Django 3.0 from CI (https://www.djangoproject.com/download/#unsupported-versions) [PR #176](https://github.com/model-bakers/model_bakery/pull/176)
+- [dev] Add explanations to imports in `generators.py` to match with current supported Django versions [PR #179](https://github.com/model-bakers/model_bakery/pull/179
 
 
 ## [1.2.1](https://pypi.org/project/model-bakery/1.2.1/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+- [dev] Add explanations to imports in `generators.py` to match with current supported Django versions [PR #179](https://github.com/model-bakers/model_bakery/pull/179)
 
 ### Changed
 
@@ -41,7 +42,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `model_bakery.timezone.smart_datetime` function (directly use `model_bakery.timezone.tz_aware` instead)  [PR #147](https://github.com/model-bakers/model_bakery/pull/147)
 - Remove all signs of Django 1.11 (as we dropped it in 1.2.1) [PR #157](https://github.com/model-bakers/model_bakery/pull/157)
 - Drop unsupported Django 3.0 from CI (https://www.djangoproject.com/download/#unsupported-versions) [PR #176](https://github.com/model-bakers/model_bakery/pull/176)
-- [dev] Add explanations to imports in `generators.py` to match with current supported Django versions [PR #179](https://github.com/model-bakers/model_bakery/pull/179
 
 
 ## [1.2.1](https://pypi.org/project/model-bakery/1.2.1/)

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -36,6 +36,8 @@ from . import random_gen
 from .utils import import_from_str
 
 try:
+    # Proper support starts with Django 3.0
+    #  (as it uses `django/db/backends/base/operations.py` for matching ranges)
     from django.db.models import AutoField, BigAutoField, SmallAutoField
 except ImportError:
     AutoField = None
@@ -43,31 +45,38 @@ except ImportError:
     SmallAutoField = None
 
 try:
+    # added in Django 3.1
     from django.db.models import PositiveBigIntegerField
 except ImportError:
     PositiveBigIntegerField = None
 
 try:
+    # Replaced `django.contrib.postgres.fields.JSONField` in Django 3.1
     from django.db.models import JSONField
 except ImportError:
     JSONField = None
 
 try:
+    # PostgreSQL-specific field (only available when psycopg2 is installed)
     from django.contrib.postgres.fields import ArrayField
 except ImportError:
     ArrayField = None
 
 try:
+    # Deprecated since Django 3.1
+    # PostgreSQL-specific field (only available when psycopg2 is installed)
     from django.contrib.postgres.fields import JSONField as PostgresJSONField
 except ImportError:
     PostgresJSONField = None
 
 try:
+    # PostgreSQL-specific field (only available when psycopg2 is installed)
     from django.contrib.postgres.fields import HStoreField
 except ImportError:
     HStoreField = None
 
 try:
+    # PostgreSQL-specific fields (only available when psycopg2 is installed)
     from django.contrib.postgres.fields.citext import (
         CICharField,
         CIEmailField,
@@ -79,22 +88,23 @@ except ImportError:
     CITextField = None
 
 try:
-    from django.contrib.postgres.fields.ranges import DecimalRangeField
-except ImportError:
-    DecimalRangeField = None
-try:
+    # PostgreSQL-specific fields (only available when psycopg2 is installed)
     from django.contrib.postgres.fields.ranges import (
         BigIntegerRangeField,
         DateRangeField,
         DateTimeRangeField,
+        DecimalRangeField,
         IntegerRangeField,
     )
 except ImportError:
-    IntegerRangeField = None
     BigIntegerRangeField = None
     DateRangeField = None
     DateTimeRangeField = None
+    DecimalRangeField = None
+    IntegerRangeField = None
+
 try:
+    # Deprecated since Django 2.2
     from django.contrib.postgres.fields.ranges import FloatRangeField
 except ImportError:
     FloatRangeField = None

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -453,10 +453,6 @@ class TestCIStringFieldsFilling:
         assert isinstance(ci_text_field, CITextField)
         assert isinstance(person.ci_text, str)
 
-    @pytest.mark.skipif(
-        not DecimalRangeField,
-        reason="Django version does not support DecimalRangeField",
-    )
     def test_filling_decimal_range_field(self, person):
         from psycopg2._range import NumericRange
 
@@ -489,7 +485,7 @@ class TestCIStringFieldsFilling:
 
     @pytest.mark.skipif(
         FloatRangeField is None,
-        reason="Django version does not support FloatRangeField",
+        reason="FloatRangeField is deprecated since Django 2.2",
     )
     def test_filling_float_range_field(self, person):
         from psycopg2._range import NumericRange


### PR DESCRIPTION
To match with currently supported Django versions (2.2+).