### PR TITLE
Fix Recipe Import Bug from Non-Installed-App Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fixed a bug (introduced in 1.2.1) that was breaking imports of recipes from non-installed-app modules [PR #201](https://github.com/model-bakers/model_bakery/pull/201)
+
 ### Removed
 
 ## [1.3.1](https://pypi.org/project/model-bakery/1.3.1/)

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -118,10 +118,10 @@ def prepare(
 
 def _recipe(name: str) -> Any:
     app_name, recipe_name = name.rsplit(".", 1)
-    if "." in app_name:  # probably full path, not app name
-        pkg = app_name
-    else:
+    try:
         pkg = apps.get_app_config(app_name).module.__package__
+    except LookupError:
+        pkg = app_name
     return import_from_str(".".join((pkg, "baker_recipes", recipe_name)))
 
 

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -10,8 +10,8 @@ from tests.generic.models import (
     Dog,
     DummyDefaultFieldsModel,
     DummyUniqueIntegerFieldModel,
-    Person,
     LonelyPerson,
+    Person,
     School,
 )
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -95,6 +95,33 @@ class TestsModelFinder:
             baker.Baker("NonExistingModel")
 
 
+class TestRecipeFinder:
+    def test_from_app_module(self):
+        obj = baker.prepare_recipe("generic.person")
+        assert isinstance(obj, models.Person)
+        assert obj.name == "John Doe"
+
+    def test_full_path_from_app_module(self):
+        obj = baker.prepare_recipe("tests.generic.person")
+        assert isinstance(obj, models.Person)
+        assert obj.name == "John Doe"
+
+    def test_from_non_app_module(self):
+        obj = baker.prepare_recipe("uninstalled.person")
+        assert isinstance(obj, models.Person)
+        assert obj.name == "Uninstalled"
+
+    def test_full_path_from_non_app_module(self):
+        obj = baker.prepare_recipe("tests.uninstalled.person")
+        assert isinstance(obj, models.Person)
+        assert obj.name == "Uninstalled"
+
+    def test_raise_on_non_module_path(self):
+        # Error trying to parse "app_name" + "recipe_name" from provided string
+        with pytest.raises(ValueError):
+            baker.prepare_recipe("person")
+
+
 @pytest.mark.django_db
 class TestsBakerCreatesSimpleModel:
     def test_consider_real_django_fields_only(self):

--- a/tests/uninstalled/baker_recipes.py
+++ b/tests/uninstalled/baker_recipes.py
@@ -1,7 +1,6 @@
 from django.utils.timezone import now
 
 from model_bakery.recipe import Recipe
-
 from tests.generic.models import Person
 
 person = Recipe(
@@ -14,5 +13,5 @@ person = Recipe(
     days_since_last_login=4,
     birthday=now().date(),
     appointment=now(),
-    birth_time=now()
+    birth_time=now(),
 )

--- a/tests/uninstalled/baker_recipes.py
+++ b/tests/uninstalled/baker_recipes.py
@@ -1,0 +1,18 @@
+from django.utils.timezone import now
+
+from model_bakery.recipe import Recipe
+
+from tests.generic.models import Person
+
+person = Recipe(
+    Person,
+    name="Uninstalled",
+    nickname="uninstalled",
+    age=18,
+    bio="Uninstalled",
+    blog="http://uninstalled.com",
+    days_since_last_login=4,
+    birthday=now().date(),
+    appointment=now(),
+    birth_time=now()
+)


### PR DESCRIPTION
Fixes #192.

Using @Arussil's suggestion from the same referenced issue, added unit tests to cover the bug case and existing behavior.