### PR TITLE
Fix recipes with `foreign_key` and `one_to_one=True`

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -367,6 +367,10 @@ class Baker(object):
                         "{0} iterator is empty.".format(field.name)
                     )
 
+        for k, v in self.model_attrs.items():
+            if is_iterator(v):
+                self.model_attrs[k] = next(v)
+
         instance = self.instance(
             self.model_attrs,
             _commit=commit,

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -13,6 +13,8 @@ from tests.generic.models import (
     LonelyPerson,
     Person,
     School,
+    User,
+    AnotherProfile,
 )
 
 person = Recipe(
@@ -34,6 +36,10 @@ serial_person = Recipe(
     Person,
     name=seq("joe"),
 )
+
+profile = Recipe(AnotherProfile, email='johndoe@example.com')
+
+user_with_profile = Recipe(User, another_profile=foreign_key(profile, one_to_one=True))
 
 serial_numbers = Recipe(
     DummyDefaultFieldsModel,

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -64,6 +64,11 @@ class User(models.Model):
     )
 
 
+class AnotherProfile(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='another_profile')
+    email = models.EmailField()
+
+
 class PaymentBill(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     value = models.FloatField()

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -412,6 +412,11 @@ class TestForeignKey:
         friend_ids = set([x.only_friend.id for x in lonely_people])
         assert len(friend_ids) == 2
 
+    def test_reverse_one_to_one_relationship(self):
+        users = baker.make_recipe("tests.generic.user_with_profile", _quantity=2)
+        profile_ids = {u.another_profile.id for u in users}
+        assert len(profile_ids) == 2
+
 
 @pytest.mark.django_db
 class TestM2MField:


### PR DESCRIPTION
fixes #204

`next` was not being called on iterator that holds related objects