### PR TITLE
_bulk_create flag is now creating related objects as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+- `_bulk_create` flag is not populating related objects as well
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
-- `_bulk_create` flag is not populating related objects as well
+- `_bulk_create` flag is not populating related objects as well [PR #206](https://github.com/model-bakers/model_bakery/pull/206)
 
 ### Changed
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -216,6 +216,22 @@ It also works with ``prepare``:
     customers = baker.prepare('shop.Customer', _quantity=3)
     assert len(customers) == 3
 
+The ``make`` method also accepts a parameter ``_bulk_create`` to use Django's `bulk_create https://docs.djangoproject.com/en/3.0/ref/models/querysets/#bulk-create`_ method instead of calling ``obj.save()`` for each created instance.
+
+**Disclaimer**: Django's ``bulk_create`` does not updates the created object primary key as explained in their docs. Because of that, there's no way for model-bakery to avoid calling ``save`` method for all the foreign keys.
+
+So, for example, if you're trying to create 20 instances of a model with a foreign key using ``_bulk_create`` this will result in 21 queries (20 for each foreign key object and one to bulk create your 20 instances).
+
+If you want to avoid that, you'll have to perform individual bulk creations per foreign keys as the following example:
+
+.. code-block:: python
+
+    from model_bakery import baker
+
+    baker.prepare(User, _quantity=5, _bulk_create=True)
+    user_iter = User.objects.all().iterator()
+    baker.prepare(Profile, user=user_iter, _quantity=5, _bulk_create=True)
+
 Multi-database support
 ----------------------
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -216,7 +216,7 @@ It also works with ``prepare``:
     customers = baker.prepare('shop.Customer', _quantity=3)
     assert len(customers) == 3
 
-The ``make`` method also accepts a parameter ``_bulk_create`` to use Django's `bulk_create https://docs.djangoproject.com/en/3.0/ref/models/querysets/#bulk-create`_ method instead of calling ``obj.save()`` for each created instance.
+The ``make`` method also accepts a parameter ``_bulk_create`` to use Django's `bulk_create <https://docs.djangoproject.com/en/3.0/ref/models/querysets/#bulk-create>`_ method instead of calling ``obj.save()`` for each created instance.
 
 **Disclaimer**: Django's ``bulk_create`` does not updates the created object primary key as explained in their docs. Because of that, there's no way for model-bakery to avoid calling ``save`` method for all the foreign keys.
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -616,7 +616,7 @@ def filter_rel_attrs(field_name: str, **rel_attrs) -> Dict[str, Any]:
     return clean_dict
 
 
-def bulk_create(baker, quantity, **kwargs):
+def bulk_create(baker, quantity, **kwargs) -> None:
     """
     Bulk create entries and all related FKs as well.
 
@@ -624,7 +624,7 @@ def bulk_create(baker, quantity, **kwargs):
     not return the created objects after a bulk_insert call.
     """
 
-    def _save_related_objs(model, objects):
+    def _save_related_objs(model, objects) -> None:
         fk_fields = [
             f
             for f in model._meta.fields

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -62,6 +62,7 @@ class User(models.Model):
     profile = models.ForeignKey(
         Profile, blank=True, null=True, on_delete=models.CASCADE
     )
+    username = models.CharField(max_length=32)
 
 
 class PaymentBill(models.Model):

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
-from django.db import connection
 from django.db.models import Manager
 from django.db.models.signals import m2m_changed
 from django.test import TestCase
@@ -20,6 +19,7 @@ from model_bakery.exceptions import (
 from model_bakery.timezone import tz_aware
 from tests.generic import models
 from tests.generic.forms import DummyGenericIPAddressFieldForm
+from tests.utils import QueryCount
 
 
 def test_import_seq_from_baker():
@@ -28,42 +28,6 @@ def test_import_seq_from_baker():
         from model_bakery.baker import seq  # NoQA
     except ImportError:
         pytest.fail("{} raised".format(ImportError.__name__))
-
-
-class QueryCount:
-    """
-    Keep track of db calls.
-
-    Example:
-    ========
-
-        qc = QueryCount()
-
-        with qc.start_count():
-            MyModel.objects.get(pk=1)
-            MyModel.objects.create()
-
-        qc.count  # 2
-
-    """
-
-    def __init__(self):
-        self.count = 0
-
-    def __call__(self, execute, sql, params, many, context):
-        """
-        `django.db.connection.execute_wrapper` callback.
-
-        https://docs.djangoproject.com/en/3.1/topics/db/instrumentation/
-        """
-        self.count += 1
-        execute(sql, params, many, context)
-
-    def start_count(self):
-        """Reset query count to 0 and return context manager for wrapping db queries."""
-        self.count = 0
-
-        return connection.execute_wrapper(self)
 
 
 class TestsModelFinder:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,37 @@
+from django.db import connection
+
+
+class QueryCount:
+    """
+    Keep track of db calls.
+
+    Example:
+    ========
+
+        qc = QueryCount()
+
+        with qc.start_count():
+            MyModel.objects.get(pk=1)
+            MyModel.objects.create()
+
+        qc.count  # 2
+
+    """
+
+    def __init__(self):
+        self.count = 0
+
+    def __call__(self, execute, sql, params, many, context):
+        """
+        `django.db.connection.execute_wrapper` callback.
+
+        https://docs.djangoproject.com/en/3.1/topics/db/instrumentation/
+        """
+        self.count += 1
+        execute(sql, params, many, context)
+
+    def start_count(self):
+        """Reset query count to 0 and return context manager for wrapping db queries."""
+        self.count = 0
+
+        return connection.execute_wrapper(self)


### PR DESCRIPTION
Fixes #202 

@amureki and @anapaulagomes please take a read before on Djangos `bulk_create` docs and you'll understand more the context behind this PR:

https://docs.djangoproject.com/en/3.0/ref/models/querysets/#bulk-create

Short summary: Django does not update the created objects via bulk and, because of that, there no way to avoid subsequent `save` calls on related objects. I've implemented with recursion because the same is true for the related of the related objects =}