### PR TITLE
[issue/211] Fix docs typos on `recipes.rst`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for iterators on GFK fields when using _quantity param [PR #207](https://github.com/model-bakers/model_bakery/pull/207)
 
 ### Changed
+- Fix typos in Recipes documentation page [PR #](https://github.com/model-bakers/model_bakery/pull/)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for iterators on GFK fields when using _quantity param [PR #207](https://github.com/model-bakers/model_bakery/pull/207)
 
 ### Changed
-- Fix typos in Recipes documentation page [PR #](https://github.com/model-bakers/model_bakery/pull/)
+- Fix typos in Recipes documentation page [PR #212](https://github.com/model-bakers/model_bakery/pull/212)
 
 ### Removed
 

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -72,8 +72,8 @@ Or if you don't want a persisted instance: ::
     use ``make_recipe``/``prepare_recipe`` by adding the tests module to the string you've passed as an argument.
     For example: ``baker.make_recipe("shop.tests.customer_joe")``
 
-    So, short summary, you can place your ``barker_recipes.py`` **anywhere** you want to and to use it having in mind
-    you'll only have to simulate an import but ofuscating the ``barker_recipes`` module from the import string.
+    So, short summary, you can place your ``baker_recipes.py`` **anywhere** you want to and to use it having in mind
+    you'll only have to simulate an import but obfuscating the ``baker_recipes`` module from the import string.
 
 
 .. note::


### PR DESCRIPTION
Fixes #211.

Addresses a couple of typos in a note on the Recipes documentation page.