### PR TITLE
add typing support to make and prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix typos in Recipes documentation page [PR #212](https://github.com/model-bakers/model_bakery/pull/212)
 - Add `venv` to ignored folders of `flake8` and `pydocstyle` [PR#214](https://github.com/model-bakers/model_bakery/pull/214)
 - Run `flake8` after code modifications when linting [PR#214](https://github.com/model-bakers/model_bakery/pull/214)
+- Add typing for `baker.make` and `baker.prepare` [PR#213](https://github.com/model-bakers/model_bakery/pull/213)
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -1,5 +1,16 @@
 from os.path import dirname, join
-from typing import Any, Callable, Dict, Iterator, List, Optional, Type, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from django.apps import apps
 from django.conf import settings
@@ -46,8 +57,11 @@ def _valid_quantity(quantity: Optional[Union[str, int]]) -> bool:
     return quantity is not None and (not isinstance(quantity, int) or quantity < 1)
 
 
+SpecificModelType = TypeVar("SpecificModelType", bound=Model)
+
+
 def make(
-    _model: Union[str, Type[ModelBase]],
+    _model: Union[str, Type[SpecificModelType]],
     _quantity: Optional[int] = None,
     make_m2m: bool = False,
     _save_kwargs: Optional[Dict] = None,
@@ -56,7 +70,7 @@ def make(
     _using: str = "",
     _bulk_create: bool = False,
     **attrs: Any
-):
+) -> Union[SpecificModelType, List[SpecificModelType]]:
     """Create a persisted instance from a given model its associated models.
 
     It fill the fields with random values or you can specify which
@@ -87,12 +101,12 @@ def make(
 
 
 def prepare(
-    _model: Union[str, Type[ModelBase]],
+    _model: Union[str, Type[SpecificModelType]],
     _quantity=None,
     _save_related=False,
     _using="",
     **attrs
-) -> Model:
+) -> Union[SpecificModelType, List[SpecificModelType]]:
     """Create but do not persist an instance from a given model.
 
     It fill the fields with random values or you can specify which
@@ -616,7 +630,7 @@ def filter_rel_attrs(field_name: str, **rel_attrs) -> Dict[str, Any]:
     return clean_dict
 
 
-def bulk_create(baker, quantity, **kwargs) -> None:
+def bulk_create(baker, quantity, **kwargs) -> List[Model]:
     """
     Bulk create entries and all related FKs as well.
 


### PR DESCRIPTION
This adds proper typing for enabling at least PyCharm to support proper code completion and silence type warnings in `baker.make` and `baker.prepare` calls.

1. Before, PyCharm was always complaining about the first parameter to `baker.make` not being of `Type[ModelBase]`, which is correct, as we're passing derived models, not the `ModelBase`.
2. Before, PyCharm was unable to provide code completion for the resulting instance. Although this is still not perfect because of the `_quantity` parameter, it now correctly lists fields and methods for the passed model class besides the `list` interface. I.e., we do not need to write `mocked_model: SomeModel = baker.make(SomeModel)` every time, and instead can rely on automatic type deduction now without explicitly specifying the model type of the variable.