### PR TITLE
Feature/improve lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Fix typos in Recipes documentation page [PR #212](https://github.com/model-bakers/model_bakery/pull/212)
+- Add `venv` to ignored folders of `flake8` and `pydocstyle` [PR#214](https://github.com/model-bakers/model_bakery/pull/214)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fix typos in Recipes documentation page [PR #212](https://github.com/model-bakers/model_bakery/pull/212)
 - Add `venv` to ignored folders of `flake8` and `pydocstyle` [PR#214](https://github.com/model-bakers/model_bakery/pull/214)
+- Run `flake8` after code modifications when linting [PR#214](https://github.com/model-bakers/model_bakery/pull/214)
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ release:
 
 lint:
 	@black .
-	@flake8 .
 	@isort .
+	@flake8 .
 	@pydocstyle .
 
 .PHONY: test release

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,9 @@ universal = 1
 max-line-length = 99
 statistics = true
 show-source = true
-exclude = docs/*
+exclude =
+    docs/*,
+    venv
 
 [tool:pytest]
 addopts = --tb=short -rxs --nomigrations
@@ -19,7 +21,7 @@ line_length=88
 
 [pydocstyle]
 add_ignore = D1
-match-dir = (?!test|docs|\.).*
+match-dir = (?!test|docs|venv|\.).*
 
 [mypy]
 ignore_missing_imports=True


### PR DESCRIPTION
This adds `venv` to the exclusion lists of flake8 and pydocstyle, and runs code-modifying linters before running style checks.

This avoids running these tools on the virtualenv and also potentially problematic modifications after successful style checks.