### PR TITLE
CI: Use python 3.10 for linters

### DIFF
--- a/tox-linter.ini
+++ b/tox-linter.ini
@@ -8,7 +8,7 @@ envlist =
 
 [gh-actions]
 python =
-    3.9: flake8,isort,pydocstyle,black,mypy
+    3.10: flake8,isort,pydocstyle,black,mypy
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
https://github.com/model-bakers/model_bakery/runs/4119324812?check_suite_focus=true

A python version mismatch led to tox job being silently skipped.
Not sure yet how to approach it to not have such issues in the future, but at least we can resolve this by fixing the version.
