### PR TITLE
Bug/through table dunder syntax fails in 1.3.3

### DIFF
--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -220,6 +220,24 @@ class RelatedNamesWithEmptyDefaultsModel(models.Model):
     )
 
 
+class AspectRatio(models.Model):
+    name = models.CharField(max_length=128)
+
+
+class PlayerContent(models.Model):
+    player = models.ForeignKey("Player", on_delete=models.CASCADE)
+    content = models.ForeignKey("Content", on_delete=models.CASCADE)
+
+
+class Content(models.Model):
+    aspect_ratio = models.ForeignKey(AspectRatio, on_delete=models.CASCADE)
+
+
+class Player(models.Model):
+    aspect_ratio = models.ForeignKey(AspectRatio, on_delete=models.CASCADE)
+    playlist = models.ManyToManyField(Content, through=PlayerContent)
+
+
 class ModelWithOverridedSave(Dog):
     def save(self, *args, **kwargs):
         self.owner = kwargs.pop("owner")

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -220,22 +220,18 @@ class RelatedNamesWithEmptyDefaultsModel(models.Model):
     )
 
 
-class AspectRatio(models.Model):
+class Player(models.Model):
+    name = models.CharField(max_length=128)
+    playlist = models.ManyToManyField("Content", through="PlayerContent")
+
+
+class Content(models.Model):
     name = models.CharField(max_length=128)
 
 
 class PlayerContent(models.Model):
-    player = models.ForeignKey("Player", on_delete=models.CASCADE)
-    content = models.ForeignKey("Content", on_delete=models.CASCADE)
-
-
-class Content(models.Model):
-    aspect_ratio = models.ForeignKey(AspectRatio, on_delete=models.CASCADE)
-
-
-class Player(models.Model):
-    aspect_ratio = models.ForeignKey(AspectRatio, on_delete=models.CASCADE)
-    playlist = models.ManyToManyField(Content, through=PlayerContent)
+    player = models.ForeignKey(Player, on_delete=models.CASCADE)
+    content = models.ForeignKey(Content, on_delete=models.CASCADE)
 
 
 class ModelWithOverridedSave(Dog):

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -330,6 +330,18 @@ class TestFillingOptionalForeignKeyField:
 
 
 @pytest.mark.django_db
+def test_filling_foreignkeys_on_through_table_with_dunder_syntax():
+    aspect_ratio = baker.make(models.AspectRatio, name="16:9")
+    dummy = baker.make(
+        models.PlayerContent,
+        content__aspect_ratio=aspect_ratio,
+        player__aspect_ratio=aspect_ratio,
+    )
+    assert dummy.content.aspect_ratio.name == "16:9"
+    assert dummy.player.aspect_ratio.name == "16:9"
+
+
+@pytest.mark.django_db
 class TestsFillingFileField:
     def test_filling_file_field(self):
         dummy = baker.make(models.DummyFileFieldModel, _create_files=True)

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -331,14 +331,13 @@ class TestFillingOptionalForeignKeyField:
 
 @pytest.mark.django_db
 def test_filling_foreignkeys_on_through_table_with_dunder_syntax():
-    aspect_ratio = baker.make(models.AspectRatio, name="16:9")
     dummy = baker.make(
         models.PlayerContent,
-        content__aspect_ratio=aspect_ratio,
-        player__aspect_ratio=aspect_ratio,
+        content__name="Indiana Jones",
+        player__name="TV"
     )
-    assert dummy.content.aspect_ratio.name == "16:9"
-    assert dummy.player.aspect_ratio.name == "16:9"
+    assert dummy.content.name == "Indiana Jones"
+    assert dummy.player.name == "TV"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Reproduction for https://github.com/model-bakers/model_bakery/issues/273