### PR TITLE
Fix random generation of ContentType values when there is no database access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fixed random generation of ContentType values when there is no database access [#290](https://github.com/model-bakers/model_bakery/pull/290)
 
 ### Removed
 

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -206,7 +206,11 @@ def gen_content_type():
 
     try:
         return ContentType.objects.get_for_model(choice(apps.get_models()))
-    except AssertionError:
+    except (AssertionError, RuntimeError):
+        # AssertionError is raised by Django's test framework when db access is not available:
+        # https://github.com/django/django/blob/stable/4.0.x/django/test/testcases.py#L150
+        # RuntimeError is raised by pytest-django when db access is not available:
+        # https://github.com/pytest-dev/pytest-django/blob/v4.5.2/pytest_django/plugin.py#L709
         warnings.warn("Database access disabled, returning ContentType raw instance")
         return ContentType()
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Manager
 from django.db.models.signals import m2m_changed
 from django.test import TestCase, override_settings
@@ -592,6 +593,7 @@ class TestHandlingContentTypeField:
     def test_create_model_with_contenttype_field(self):
         dummy = baker.make(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
+        assert isinstance(dummy.content_type, ContentType)
 
 
 class TestHandlingContentTypeFieldNoQueries:
@@ -602,6 +604,7 @@ class TestHandlingContentTypeFieldNoQueries:
         ):
             dummy = baker.prepare(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
+        assert isinstance(dummy.content_type, ContentType)
 
 
 @pytest.mark.django_db

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -594,7 +594,6 @@ class TestHandlingContentTypeField:
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
 
 
-@pytest.mark.django_db
 class TestHandlingContentTypeFieldNoQueries:
     def test_create_model_with_contenttype_field(self):
         dummy = baker.prepare(models.DummyGenericForeignKeyModel)

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -615,6 +615,11 @@ class TestHandlingContentTypeField:
 
 class TestHandlingContentTypeFieldNoQueries:
     def test_create_model_with_contenttype_field(self):
+        # Clear ContentType's internal cache so that it *will* try to connect to
+        # the database in order to fetch the corresponding ContentType model for
+        # a randomly chosen model.
+        ContentType.objects.clear_cache()
+
         with pytest.warns(
             UserWarning,
             match="Database access disabled, returning ContentType raw instance",

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -596,7 +596,11 @@ class TestHandlingContentTypeField:
 
 class TestHandlingContentTypeFieldNoQueries:
     def test_create_model_with_contenttype_field(self):
-        dummy = baker.prepare(models.DummyGenericForeignKeyModel)
+        with pytest.warns(
+            UserWarning,
+            match="Database access disabled, returning ContentType raw instance",
+        ):
+            dummy = baker.prepare(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
 
 


### PR DESCRIPTION
## Context
I wrote a test in pytest that does:

```python
baker.prepare(SomeModel, _fill_optional=True)
```

and it failed with:

> RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it. 

model_bakery was trying to generate a ContentType value to fill in with and the first thing it does is to fetch a random value from the database:

```sh
path/to/venv/lib/python3.7/site-packages/model_bakery/random_gen.py:208: in gen_content_type
    return ContentType.objects.get_for_model(choice(apps.get_models()))
```

The `gen_content_type()` function tries to remediate when database access is not available:
https://github.com/model-bakers/model_bakery/blob/1.4.0/model_bakery/random_gen.py#L207-L211

```python
    try:
        return ContentType.objects.get_for_model(choice(apps.get_models()))
    except AssertionError:
        warnings.warn("Database access disabled, returning ContentType raw instance")
        return ContentType()
```

But in the case of pytest-django, a `RuntimeError` is raised, not an `AssertionError`: https://github.com/pytest-dev/pytest-django/blob/v4.5.2/pytest_django/plugin.py#L709-L713

## What this PR does

This PR adds `RuntimeError` to the exception classes that are caught by the try-except block in `gen_content_type()`.