### PR TITLE
Better type hints for model_bakery.recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Extend type hints in `model_bakery.recipe` module, make `Recipe` class generic [PR #292](https://github.com/model-bakers/model_bakery/pull/292)
 
 ### Removed
 

--- a/model_bakery/_types.py
+++ b/model_bakery/_types.py
@@ -1,0 +1,6 @@
+from typing import TypeVar
+from django.db.models import Model
+
+
+M = TypeVar("M", bound=Model)
+NewM = TypeVar("NewM", bound=Model)

--- a/model_bakery/_types.py
+++ b/model_bakery/_types.py
@@ -1,6 +1,6 @@
 from typing import TypeVar
-from django.db.models import Model
 
+from django.db.models import Model
 
 M = TypeVar("M", bound=Model)
 NewM = TypeVar("NewM", bound=Model)

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -34,6 +34,7 @@ from django.db.models.fields.related import (
 from django.db.models.fields.reverse_related import ManyToOneRel, OneToOneRel
 
 from . import generators, random_gen
+from ._types import M, NewM
 from .exceptions import (
     AmbiguousModelName,
     CustomBakerNotFound,
@@ -44,7 +45,6 @@ from .exceptions import (
 )
 from .utils import seq  # NoQA: enable seq to be imported from baker
 from .utils import import_from_str
-from ._types import M, NewM
 
 recipes = None
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -44,6 +44,7 @@ from .exceptions import (
 )
 from .utils import seq  # NoQA: enable seq to be imported from baker
 from .utils import import_from_str
+from ._types import M, NewM
 
 recipes = None
 
@@ -56,10 +57,6 @@ MAX_MANY_QUANTITY = 5
 
 def _valid_quantity(quantity: Optional[Union[str, int]]) -> bool:
     return quantity is not None and (not isinstance(quantity, int) or quantity < 1)
-
-
-M = TypeVar("M", bound=Model)
-NewM = TypeVar("NewM", bound=Model)
 
 
 @overload

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -8,7 +8,6 @@ from typing import (
     List,
     Optional,
     Type,
-    TypeVar,
     Union,
     cast,
     overload,

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -15,13 +15,12 @@ from typing import (
 from django.db.models import Model
 
 from . import baker
+from ._types import M
 from .exceptions import RecipeNotFound
 from .utils import (  # NoQA: Enable seq to be imported from recipes
     get_calling_module,
     seq,
 )
-from ._types import M
-
 
 finder = baker.ModelFinder()
 

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -1,5 +1,16 @@
 import itertools
-from typing import Any, Dict, List, Type, Union, cast
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from django.db.models import Model
 
@@ -9,18 +20,22 @@ from .utils import (  # NoQA: Enable seq to be imported from recipes
     get_calling_module,
     seq,
 )
+from ._types import M
+
 
 finder = baker.ModelFinder()
 
 
-class Recipe(object):
-    def __init__(self, _model: Union[str, Type[Model]], **attrs) -> None:
+class Recipe(Generic[M]):
+    _T = TypeVar("_T", bound="Recipe[M]")
+
+    def __init__(self, _model: Union[str, Type[M]], **attrs: Any) -> None:
         self.attr_mapping = attrs
         self._model = _model
         # _iterator_backups will hold values of the form (backup_iterator, usable_iterator).
         self._iterator_backups = {}  # type: Dict[str, Any]
 
-    def _mapping(self, _using, new_attrs: Dict[str, Any]) -> Dict[str, Any]:
+    def _mapping(self, _using: str, new_attrs: Dict[str, Any]) -> Dict[str, Any]:
         _save_related = new_attrs.get("_save_related", True)
         _quantity = new_attrs.get("_quantity")
         if _quantity is None:
@@ -66,23 +81,99 @@ class Recipe(object):
         mapping.update(rel_fields_attrs)
         return mapping
 
-    def make(self, _using="", **attrs: Any) -> Union[Model, List[Model]]:
-        return baker.make(self._model, _using=_using, **self._mapping(_using, attrs))
+    @overload
+    def make(
+        self,
+        _quantity: None = None,
+        make_m2m: bool = False,
+        _refresh_after_create: bool = False,
+        _create_files: bool = False,
+        _using: str = "",
+        _bulk_create: bool = False,
+        _save_kwargs: Optional[Dict[str, Any]] = None,
+        **attrs: Any,
+    ) -> M:
+        ...
 
-    def prepare(self, _using="", **attrs: Any) -> Union[Model, List[Model]]:
-        defaults = {"_save_related": False}
+    @overload
+    def make(
+        self,
+        _quantity: int,
+        make_m2m: bool = False,
+        _refresh_after_create: bool = False,
+        _create_files: bool = False,
+        _using: str = "",
+        _bulk_create: bool = False,
+        _save_kwargs: Optional[Dict[str, Any]] = None,
+        **attrs: Any,
+    ) -> List[M]:
+        ...
+
+    def make(
+        self,
+        _quantity: Optional[int] = None,
+        make_m2m: bool = False,
+        _refresh_after_create: bool = False,
+        _create_files: bool = False,
+        _using: str = "",
+        _bulk_create: bool = False,
+        _save_kwargs: Optional[Dict[str, Any]] = None,
+        **attrs: Any,
+    ) -> Union[M, List[M]]:
+        defaults = {
+            "_quantity": _quantity,
+            "make_m2m": make_m2m,
+            "_refresh_after_create": _refresh_after_create,
+            "_create_files": _create_files,
+            "_bulk_create": _bulk_create,
+            "_save_kwargs": _save_kwargs,
+        }
+        defaults.update(attrs)
+        return baker.make(self._model, _using=_using, **self._mapping(_using, defaults))
+
+    @overload
+    def prepare(
+        self,
+        _quantity: None = None,
+        _save_related: bool = False,
+        _using: str = "",
+        **attrs: Any,
+    ) -> M:
+        ...
+
+    @overload
+    def prepare(
+        self,
+        _quantity: int,
+        _save_related: bool = False,
+        _using: str = "",
+        **attrs: Any,
+    ) -> List[M]:
+        ...
+
+    def prepare(
+        self,
+        _quantity: Optional[int] = None,
+        _save_related: bool = False,
+        _using: str = "",
+        **attrs: Any,
+    ) -> Union[M, List[M]]:
+        defaults = {
+            "_quantity": _quantity,
+            "_save_related": _save_related,
+        }
         defaults.update(attrs)
         return baker.prepare(
             self._model, _using=_using, **self._mapping(_using, defaults)
         )
 
-    def extend(self, **attrs) -> "Recipe":
+    def extend(self: _T, **attrs: Any) -> _T:
         attr_mapping = self.attr_mapping.copy()
         attr_mapping.update(attrs)
         return type(self)(self._model, **attr_mapping)
 
 
-def _load_recipe_from_calling_module(recipe: str) -> Recipe:
+def _load_recipe_from_calling_module(recipe: str) -> Recipe[Model]:
     """Load `Recipe` from the string attribute given from the calling module.
 
     Args:
@@ -94,15 +185,15 @@ def _load_recipe_from_calling_module(recipe: str) -> Recipe:
     """
     recipe = getattr(get_calling_module(2), recipe)
     if recipe:
-        return cast(Recipe, recipe)
+        return cast(Recipe[Model], recipe)
     else:
         raise RecipeNotFound
 
 
-class RecipeForeignKey(object):
+class RecipeForeignKey(Generic[M]):
     """A `Recipe` to use for making ManyToOne and OneToOne related objects."""
 
-    def __init__(self, recipe: Recipe, one_to_one: bool) -> None:
+    def __init__(self, recipe: Recipe[M], one_to_one: bool) -> None:
         if isinstance(recipe, Recipe):
             self.recipe = recipe
             self.one_to_one = one_to_one
@@ -111,8 +202,8 @@ class RecipeForeignKey(object):
 
 
 def foreign_key(
-    recipe: Union[Recipe, str], one_to_one: bool = False
-) -> RecipeForeignKey:
+    recipe: Union[Recipe[M], str], one_to_one: bool = False
+) -> RecipeForeignKey[M]:
     """Return a `RecipeForeignKey`.
 
     Return the callable, so that the associated `_model` will not be created
@@ -130,12 +221,12 @@ def foreign_key(
             # Probably not in another module, so load it from calling module
             recipe = _load_recipe_from_calling_module(cast(str, recipe))
 
-    return RecipeForeignKey(cast(Recipe, recipe), one_to_one)
+    return RecipeForeignKey(cast(Recipe[M], recipe), one_to_one)
 
 
-class related(object):  # FIXME
-    def __init__(self, *args) -> None:
-        self.related = []  # type: List[Recipe]
+class related(Generic[M]):  # FIXME
+    def __init__(self, *args: Union[str, Recipe[M]]) -> None:
+        self.related = []  # type: List[Recipe[M]]
         for recipe in args:
             if isinstance(recipe, Recipe):
                 self.related.append(recipe)
@@ -148,6 +239,6 @@ class related(object):  # FIXME
             else:
                 raise TypeError("Not a recipe")
 
-    def make(self) -> List[Union[Model, List[Model]]]:
+    def make(self) -> List[Union[M, List[M]]]:
         """Persist objects to m2m relation."""
         return [m.make() for m in self.related]

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -125,7 +125,7 @@ class TestsBakerCreatesSimpleModel:
         instance = baker.make(models.SubclassOfAbstract)
         assert isinstance(instance, models.SubclassOfAbstract)
         assert isinstance(instance, models.AbstractModel)
-        assert isinstance(instance.name, type(u""))
+        assert isinstance(instance.name, type(""))
         assert len(instance.name) == 30
         assert isinstance(instance.height, int)
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -277,8 +277,10 @@ class TestFillingGenericForeignKeyField:
 
     def test_iteratively_filling_generic_foreign_key_field(self):
         """
-        Ensures private_fields are included in Baker.get_fields(), otherwise
-        calling next() when a GFK is in iterator_attrs would be bypassed.
+        Ensures private_fields are included in ``Baker.get_fields()``.
+
+        Otherwise, calling ``next()`` when a GFK is in ``iterator_attrs``
+        would be bypassed.
         """
         objects = baker.make(models.Profile, _quantity=2)
         dummies = baker.make(

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -48,8 +48,7 @@ def test_import_seq_from_recipe():
 
 
 def test_import_recipes():
-    """Test imports works both for full import paths and for
-    `app_name.recipe_name` strings."""
+    """Test imports works both for full import paths and for `app_name.recipe_name` strings."""
     assert baker.prepare_recipe("generic.dog"), baker.prepare_recipe(
         "tests.generic.dog"
     )


### PR DESCRIPTION
### Motivation

Using generic types in ``model_bakery.recipe`` module allows for better hints from IDEs (if supported). Generic types are part of the stdlib's ``typing`` since 3.5, so the changes are conform with the range of Python versions currently supported by the library (although note that 3.5 and 3.6 are EOL already).

### Demo (Pycharm)

![image](https://user-images.githubusercontent.com/4455652/153686109-88da8226-ec3b-463c-8f45-86f5f8940319.png)
![image](https://user-images.githubusercontent.com/4455652/153686132-1aedd6af-6a6a-4593-b51d-cfbfc56c5db1.png)
![image](https://user-images.githubusercontent.com/4455652/153686149-d85b2c7d-a5f0-471a-8ab3-09e37e0aa922.png)

### Demo (``mypy``)

Sample code snippet:
```py
from django.db.models import Model, ForeignKey
from model_bakery.recipe import Recipe, foreign_key, related

class C(Model):
    ...

r = Recipe(C)

reveal_type(r)
reveal_type(r.extend(spam="eggs"))
reveal_type(r.make())
reveal_type(r.make(_quantity=None))
reveal_type(r.make(_quantity=100))
reveal_type(foreign_key(Recipe(C)))
reveal_type(related(r, r))
```
On current mainline, ``mypy`` will emit
```
test.py:14: note: Revealed type is "model_bakery.recipe.Recipe"
test.py:15: note: Revealed type is "model_bakery.recipe.Recipe"
test.py:16: note: Revealed type is "Union[django.db.models.base.Model, builtins.list[django.db.models.base.Model]]"
test.py:17: note: Revealed type is "Union[django.db.models.base.Model, builtins.list[django.db.models.base.Model]]"
test.py:18: note: Revealed type is "Union[django.db.models.base.Model, builtins.list[django.db.models.base.Model]]"
test.py:19: note: Revealed type is "model_bakery.recipe.RecipeForeignKey"
test.py:20: note: Revealed type is "model_bakery.recipe.related"
```
whereas with this PR, more fine-grained type hinting is made available:
```
test.py:14: note: Revealed type is "model_bakery.recipe.Recipe[test.C*]"
test.py:15: note: Revealed type is "model_bakery.recipe.Recipe[test.C]"
test.py:16: note: Revealed type is "test.C*"
test.py:17: note: Revealed type is "test.C*"
test.py:18: note: Revealed type is "builtins.list[test.C*]"
test.py:19: note: Revealed type is "model_bakery.recipe.RecipeForeignKey[test.C*]"
test.py:20: note: Revealed type is "model_bakery.recipe.related[test.C*]"
```