### PR TITLE
Do not bypass many-to-many related fields.

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -30,7 +30,11 @@ from django.db.models.fields.proxy import OrderWrt
 from django.db.models.fields.related import (
     ReverseManyToOneDescriptor as ForeignRelatedObjectsDescriptor,
 )
-from django.db.models.fields.reverse_related import ManyToOneRel, OneToOneRel
+from django.db.models.fields.reverse_related import (
+    ManyToManyRel,
+    ManyToOneRel,
+    OneToOneRel,
+)
 
 from . import generators, random_gen
 from ._types import M, NewM
@@ -404,8 +408,8 @@ class Baker(Generic[M]):
 
     def get_related(
         self,
-    ) -> List[Union[ManyToOneRel, OneToOneRel]]:
-        return [r for r in self.model._meta.related_objects if not r.many_to_many]
+    ) -> List[Union[ManyToOneRel, OneToOneRel, ManyToManyRel]]:
+        return [r for r in self.model._meta.related_objects]
 
     def _make(
         self,

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -231,6 +231,16 @@ class Classroom(models.Model):
     active = models.BooleanField(null=True)
 
 
+class ClassroomM2MRelated(models.Model):
+    """
+    This model was created in order to reproduce the scenario described
+    at issue 248 that is: a model with a M2M field (Classroom) being also used
+    as a M2M field from another model (ClassroomM2MRelated)
+    """
+
+    related_classrooms = models.ManyToManyField(Classroom)
+
+
 class Store(models.Model):
     customers = models.ManyToManyField(Person, related_name="favorite_stores")
     employees = models.ManyToManyField(Person, related_name="employers")


### PR DESCRIPTION
Fixes #248 

The issue has all the important discussion on the reasons behind this PR.  But the if condition was bypassing related m2m and, thus, considering them as regular fields of the model.