### PR TITLE
Get ManyToOneRel fields (reverse FK) back to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Extend type hints in `model_bakery.recipe` module, make `Recipe` class generic [PR #292](https://github.com/model-bakers/model_bakery/pull/292)
 - Explicitly add _fill_optional parameters to baker.make and baker.prepare to aid IDE autocomplete function. [PR #264](https://github.com/model-bakers/model_bakery/pull/264)
 - Fixed errors with reverse M2M relationships [PR #299](https://github.com/model-bakers/model_bakery/pull/299)
+- Fixed errors with reverse M2O relationships [PR #300](https://github.com/model-bakers/model_bakery/pull/300)
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -609,11 +609,13 @@ class Baker(Generic[M]):
                 # Django will handle any operation to persist nested non-persisted FK because
                 # save don't do so and, thus, raise constraint errors. That's why save() only gets
                 # called if the object doesn't have a pk and also doesn't hold fk pointers
-                fks = any([
-                    fk
-                    for fk in value._meta.fields
-                    if isinstance(fk, ForeignKey) or isinstance(fk, OneToOneField)
-                ])
+                fks = any(
+                    [
+                        fk
+                        for fk in value._meta.fields
+                        if isinstance(fk, ForeignKey) or isinstance(fk, OneToOneField)
+                    ]
+                )
                 if not value.pk and not fks:
                     value.save()
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -607,8 +607,9 @@ class Baker(Generic[M]):
 
             for value in values:
                 # Django will handle any operation to persist nested non-persisted FK because
-                # save doesn't do so and, thus, raises constraint errors. That's why save() only gets
-                # called if the object doesn't have a pk and also doesn't hold fk pointers
+                # save doesn't do so and, thus, raises constraint errors. That's why save()
+                # only gets called if the object doesn't have a pk and also doesn't hold fk
+                # pointers.
                 fks = any(
                     [
                         fk

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -607,7 +607,7 @@ class Baker(Generic[M]):
 
             for value in values:
                 # Django will handle any operation to persist nested non-persisted FK because
-                # save don't do so and, thus, raise constraint errors. That's why save() only gets
+                # save doesn't do so and, thus, raises constraint errors. That's why save() only gets
                 # called if the object doesn't have a pk and also doesn't hold fk pointers
                 fks = any(
                     [

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -606,7 +606,15 @@ class Baker(Generic[M]):
             manager = getattr(instance, key)
 
             for value in values:
-                if not value.pk:
+                # Django will handle any operation to persist nested non-persisted FK because
+                # save don't do so and, thus, raise constraint errors. That's why save() only gets
+                # called if the object doesn't have a pk and also doesn't hold fk pointers
+                fks = any([
+                    fk
+                    for fk in value._meta.fields
+                    if isinstance(fk, ForeignKey) or isinstance(fk, OneToOneField)
+                ])
+                if not value.pk and not fks:
                     value.save()
 
             try:

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -457,7 +457,7 @@ class NonStandardManager(models.Model):
     manager = models.Manager()
 
 
-### The followin models were added after issue 291
+# The followin models were added after issue 291
 # Since they doesn't hold much meaning, they are only numbered ones
 class Issue291Model1(models.Model):
     pass
@@ -468,5 +468,7 @@ class Issue291Model2(models.Model):
 
 
 class Issue291Model3(models.Model):
-    fk_model_2 = models.ForeignKey(Issue291Model2, related_name="bazs", on_delete=models.CASCADE)
+    fk_model_2 = models.ForeignKey(
+        Issue291Model2, related_name="bazs", on_delete=models.CASCADE
+    )
     name = models.CharField(max_length=32)

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -458,7 +458,7 @@ class NonStandardManager(models.Model):
 
 
 # The followin models were added after issue 291
-# Since they doesn't hold much meaning, they are only numbered ones
+# Since they don't hold much meaning, they are only numbered ones
 class Issue291Model1(models.Model):
     pass
 

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -455,3 +455,18 @@ class NonStandardManager(models.Model):
     name = models.CharField(max_length=30)
 
     manager = models.Manager()
+
+
+### The followin models were added after issue 291
+# Since they doesn't hold much meaning, they are only numbered ones
+class Issue291Model1(models.Model):
+    pass
+
+
+class Issue291Model2(models.Model):
+    m2m_model_1 = models.ManyToManyField(Issue291Model1)
+
+
+class Issue291Model3(models.Model):
+    fk_model_2 = models.ForeignKey(Issue291Model2, related_name="bazs", on_delete=models.CASCADE)
+    name = models.CharField(max_length=32)

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -571,7 +571,9 @@ class TestBakerCreatesAssociatedModels(TestCase):
 
     def test_ensure_reverse_fk_for_many_to_one_is_working(self):
         """This is a regression test to make sure issue 291 is fixed"""
-        fk1, fk2 = baker.prepare(models.Issue291Model3, fk_model_2=None, name="custom name", _quantity=2)
+        fk1, fk2 = baker.prepare(
+            models.Issue291Model3, fk_model_2=None, name="custom name", _quantity=2
+        )
         obj = baker.make(
             models.Issue291Model2,
             m2m_model_1=[baker.make(models.Issue291Model1)],

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -569,6 +569,20 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert not person.pk
         assert 0 == models.RelatedNamesModel.objects.count()
 
+    def test_ensure_reverse_fk_for_many_to_one_is_working(self):
+        """This is a regression test to make sure issue 291 is fixed"""
+        fk1, fk2 = baker.prepare(models.Issue291Model3, fk_model_2=None, name="custom name", _quantity=2)
+        obj = baker.make(
+            models.Issue291Model2,
+            m2m_model_1=[baker.make(models.Issue291Model1)],
+            bazs=[fk1, fk2],
+        )
+
+        assert obj.bazs.count() == 2
+        related_1, related_2 = obj.bazs.all()
+        assert related_1.name == "custom name"
+        assert related_2.name == "custom name"
+
 
 @pytest.mark.django_db
 class TestHandlingUnsupportedModels:


### PR DESCRIPTION
Fixes #291 

Given the way Django's `Model.save()` works, the code was breaking when trying to prepared (via `baker.prepare`) objects which hold FK for other prepared instances. The `save` call only persists the current model and not the subsequent ones. 

Meanwhile, django manager's `set` or `add` methods does handle nested persistence, but doesn't know how to save models which doesn't hold other FKs (or at least this is what I understood from the issue).

So, this PR introduces a fixes to only save an object before adding it to the related model if it doesn't have any FK. Other scenarios should now be handled by Django