### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
-
+- Drop Python 3.6 support [PR #323](https://github.com/model-bakers/model_bakery/pull/323)
 
 ## [1.5.0](https://pypi.org/project/model-bakery/1.5.0/)
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
         "Topic :: Software Development",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py36-django{22,32}-{postgresql,sqlite}
     py37-django{22,32}-{postgresql,sqlite}
     py38-django{22,32,40}-{postgresql,sqlite}
     py39-django{22,32,40}-{postgresql,sqlite}
@@ -8,7 +7,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
2021-12-23 it reached end-of-life:
https://www.python.org/dev/peps/pep-0494/#lifespan
