### PR TITLE
Drop Django 2.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
-- Drop Python 3.6 support [PR #323](https://github.com/model-bakers/model_bakery/pull/323)
+- Drop Python 3.6 support [PR #325](https://github.com/model-bakers/model_bakery/pull/325)
+- Drop Django 2.2 support [PR #326](https://github.com/model-bakers/model_bakery/pull/326)
 
 ## [1.5.0](https://pypi.org/project/model-bakery/1.5.0/)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ Model Bakery is a rename of the legacy `model_mommy's project <https://pypi.org/
 Compatibility
 =============
 
-Model Bakery supports Django >= 2.2.
+Model Bakery supports Django >= 3.2.
 
 Install
 =======

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django>=2.2
+django>=3.2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setuptools.setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py37-django{22,32}-{postgresql,sqlite}
-    py38-django{22,32,40}-{postgresql,sqlite}
-    py39-django{22,32,40}-{postgresql,sqlite}
-    py310-django{32,40}
+    py37-django{32}-{postgresql,sqlite}
+    py38-django{32,40}-{postgresql,sqlite}
+    py39-django{32,40}-{postgresql,sqlite}
+    py310-django{32,40}-{postgresql,sqlite}
 
 [gh-actions]
 python =
@@ -23,8 +23,7 @@ deps =
     pillow
     pytest
     pytest-django
-    django22: Django==2.2
-    django32: Django>=3.2,<3.3
+    django32: Django==3.2
     django40: Django>=4.0,<4.1
     postgresql: psycopg2-binary
 commands =


### PR DESCRIPTION
It reached end-of-life 2022-04-11:
https://www.djangoproject.com/download/#supported-versions
