### PR TITLE
Replace changelog reminder action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,14 +1,16 @@
-on: pull_request
-
 name: Changelog Reminder
+
+on: pull_request
 
 jobs:
   remind:
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.body, '[skip changelog]') &&
+      (github.actor != 'dependabot[bot]')
     steps:
-    - uses: actions/checkout@main
-    - uses: peterjgrainger/action-changelog-reminder@v1.3.0
-      with:
-        changelog_regex: 'CHANGELOG.md'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ github.event.pull_request.commits }} + 1
+      - name: Check that CHANGELOG is updated
+        run: git diff origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Django 4.1 support [PR #327](https://github.com/model-bakers/model_bakery/pull/327)
 
 ### Changed
+- [dev] Replace changelog reminder action with a custom solution that can ignore Dependabot PRs [PR #328](https://github.com/model-bakers/model_bakery/pull/328)
 
 ### Removed
 - Drop Python 3.6 support [PR #325](https://github.com/model-bakers/model_bakery/pull/325)


### PR DESCRIPTION
... with a custom solution that can ignore Dependabot PRs.

Check still works, here is a first commit without a changelog:
https://github.com/model-bakers/model_bakery/actions/runs/2564748259