### PR TITLE
Fix #308 -- do not force defaults for `make` and `prepare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+
 ### Changed
+- Fixed a bug with overwritten `_save_kwargs` and other custom arguments [PR #330](https://github.com/model-bakers/model_bakery/pull/330)
+
 ### Removed
 
 ## [1.6.0](https://pypi.org/project/model-bakery/1.6.0/)

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -111,22 +111,28 @@ class Recipe(Generic[M]):
     def make(
         self,
         _quantity: Optional[int] = None,
-        make_m2m: bool = False,
-        _refresh_after_create: bool = False,
-        _create_files: bool = False,
+        make_m2m: Optional[bool] = None,
+        _refresh_after_create: Optional[bool] = None,
+        _create_files: Optional[bool] = None,
         _using: str = "",
-        _bulk_create: bool = False,
+        _bulk_create: Optional[bool] = None,
         _save_kwargs: Optional[Dict[str, Any]] = None,
         **attrs: Any,
     ) -> Union[M, List[M]]:
-        defaults = {
-            "_quantity": _quantity,
-            "make_m2m": make_m2m,
-            "_refresh_after_create": _refresh_after_create,
-            "_create_files": _create_files,
-            "_bulk_create": _bulk_create,
-            "_save_kwargs": _save_kwargs,
-        }
+        defaults = {}
+        if _quantity is not None:
+            defaults["_quantity"] = _quantity
+        if make_m2m is not None:
+            defaults["make_m2m"] = make_m2m
+        if _refresh_after_create is not None:
+            defaults["_refresh_after_create"] = _refresh_after_create
+        if _create_files is not None:
+            defaults["_create_files"] = _create_files
+        if _bulk_create is not None:
+            defaults["_bulk_create"] = _bulk_create
+        if _save_kwargs is not None:
+            defaults["_save_kwargs"] = _save_kwargs
+
         defaults.update(attrs)
         return baker.make(self._model, _using=_using, **self._mapping(_using, defaults))
 
@@ -157,10 +163,9 @@ class Recipe(Generic[M]):
         _using: str = "",
         **attrs: Any,
     ) -> Union[M, List[M]]:
-        defaults = {
-            "_quantity": _quantity,
-            "_save_related": _save_related,
-        }
+        defaults = {"_save_related": _save_related}
+        if _quantity is not None:
+            defaults["_quantity"] = _quantity
         defaults.update(attrs)
         return baker.prepare(
             self._model, _using=_using, **self._mapping(_using, defaults)

--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -131,7 +131,7 @@ class Recipe(Generic[M]):
         if _bulk_create is not None:
             defaults["_bulk_create"] = _bulk_create
         if _save_kwargs is not None:
-            defaults["_save_kwargs"] = _save_kwargs
+            defaults["_save_kwargs"] = _save_kwargs  # type: ignore[assignment]
 
         defaults.update(attrs)
         return baker.make(self._model, _using=_using, **self._mapping(_using, defaults))
@@ -163,9 +163,10 @@ class Recipe(Generic[M]):
         _using: str = "",
         **attrs: Any,
     ) -> Union[M, List[M]]:
-        defaults = {"_save_related": _save_related}
-        if _quantity is not None:
-            defaults["_quantity"] = _quantity
+        defaults = {
+            "_quantity": _quantity,
+            "_save_related": _save_related,
+        }
         defaults.update(attrs)
         return baker.prepare(
             self._model, _using=_using, **self._mapping(_using, defaults)

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -113,6 +113,10 @@ movie_with_cast = Recipe(
 
 overrided_save = Recipe("generic.ModelWithOverridedSave")
 
+with_save_kwargs = Recipe(
+    "generic.ModelWithSaveKwargs", _save_kwargs={"breed": "updated_breed"}
+)
+
 ip_fields = Recipe(
     "generic.DummyGenericIPAddressFieldModel",
     ipv4_field=seq("127.0.0.", increment_by=2),

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -223,13 +223,13 @@ class RelatedNamesWithEmptyDefaultsModel(models.Model):
 class ModelWithOverridedSave(Dog):
     def save(self, *args, **kwargs):
         self.owner = kwargs.pop("owner")
-        return super(ModelWithOverridedSave, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
 
 class ModelWithSaveKwargs(Dog):
     def save(self, *args, **kwargs):
         self.breed = kwargs.pop("breed")
-        return super(ModelWithSaveKwargs, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
 
 class Classroom(models.Model):

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -226,6 +226,12 @@ class ModelWithOverridedSave(Dog):
         return super(ModelWithOverridedSave, self).save(*args, **kwargs)
 
 
+class ModelWithSaveKwargs(Dog):
+    def save(self, *args, **kwargs):
+        self.breed = kwargs.pop("breed")
+        return super(ModelWithSaveKwargs, self).save(*args, **kwargs)
+
+
 class Classroom(models.Model):
     students = models.ManyToManyField(Person, null=True)
     active = models.BooleanField(null=True)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -332,6 +332,10 @@ class TestExecutingRecipes:
         )
         assert owner == dog.owner
 
+    def test_pass_save_kwargs_in_recipe_definition(self):
+        dog = baker.make_recipe("tests.generic.with_save_kwargs")
+        assert dog.breed == "updated_breed"
+
     def test_ip_fields_with_start(self):
         first, second = baker.make_recipe("tests.generic.ip_fields", _quantity=2)
 


### PR DESCRIPTION
PR #292 introduced explicit defaults for `make` and `prepare`,
which were then overwriting custom values in certain cases (explained in #308).

This PR attempts to fix this issue by not having explicit defaults.
