### PR TITLE
fix future deprecate warning of django.utils.timezone.utc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Remove warning for future Django deprecation [PR #339](https://github.com/model-bakers/model_bakery/pull/339)
 
 ### Removed
 

--- a/model_bakery/timezone.py
+++ b/model_bakery/timezone.py
@@ -1,14 +1,13 @@
 """Utility functions to manage timezone code."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.conf import settings
-from django.utils.timezone import utc
 
 
 def tz_aware(value: datetime) -> datetime:
     """Return an UTC-aware datetime in case of USE_TZ=True."""
     if settings.USE_TZ:
-        value = value.replace(tzinfo=utc)
+        value = value.replace(tzinfo=timezone.utc)
 
     return value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from inspect import getmodule
 
 import pytest
-from django.utils.timezone import utc
 
 from model_bakery.utils import get_calling_module, import_from_str, seq
 from tests.generic.models import User
@@ -145,7 +144,7 @@ class TestSeq:
     @pytest.mark.parametrize("use_tz", [False, True])
     def test_datetime(self, settings, use_tz):
         settings.USE_TZ = use_tz
-        tzinfo = utc if use_tz else None
+        tzinfo = datetime.timezone.utc if use_tz else None
 
         sequence = seq(
             datetime.datetime(2021, 2, 11, 15, 39, 58, 457698),


### PR DESCRIPTION
**Describe the change**
Make code compatible with future Django release.

```
model_bakery/timezone.py:6: RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.
    from django.utils.timezone import utc
```

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
