### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -314,7 +314,7 @@ epub_copyright = "2014, Lucas Simon Rodrigues Magalhaes"
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -463,7 +463,7 @@ class NonStandardManager(models.Model):
     manager = models.Manager()
 
 
-# The followin models were added after issue 291
+# The following models were added after issue 291
 # Since they don't hold much meaning, they are only numbered ones
 class Issue291Model1(models.Model):
     pass


### PR DESCRIPTION
There are small typos in:
- docs/source/conf.py
- tests/generic/models.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `following` rather than `followin`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md