### PR TITLE
[#322] Fix `seq` for timezone-aware start value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fixed a bug with `seq` being passed a tz-aware start value [PR #353](https://github.com/model-bakers/model_bakery/pull/353)
 
 ### Removed
 

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -82,7 +82,8 @@ def seq(value, increment_by=1, start=None, suffix=None):
             date = value
 
         # convert to epoch time
-        start = (date - datetime.datetime(1970, 1, 1)).total_seconds()
+        epoch_datetime = datetime.datetime(1970, 1, 1, tzinfo=date.tzinfo)
+        start = (date - epoch_datetime).total_seconds()
         increment_by = increment_by.total_seconds()
         for n in itertools.count(increment_by, increment_by):
             series_date = tz_aware(datetime.datetime.utcfromtimestamp(start + n))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,6 +146,7 @@ class TestSeq:
         settings.USE_TZ = use_tz
         tzinfo = datetime.timezone.utc if use_tz else None
 
+        # Starting with tz-unaware (naive) datetime
         sequence = seq(
             datetime.datetime(2021, 2, 11, 15, 39, 58, 457698),
             increment_by=datetime.timedelta(hours=3),
@@ -158,6 +159,15 @@ class TestSeq:
         ).replace(tzinfo=tzinfo)
         assert next(sequence) == datetime.datetime(
             2021, 2, 12, 00, 39, 58, 457698
+        ).replace(tzinfo=tzinfo)
+
+        # Starting with tz-aware datetime
+        sequence = seq(
+            datetime.datetime(2021, 2, 11, 15, 39, 58, 457698, tzinfo=tzinfo),
+            increment_by=datetime.timedelta(hours=3),
+        )
+        assert next(sequence) == datetime.datetime(
+            2021, 2, 11, 18, 39, 58, 457698
         ).replace(tzinfo=tzinfo)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #322. Allows `seq` to properly increment from a timezone-aware starting datetime.

**PR Checklist**
- [X] Change is covered with tests
- [X] [CHANGELOG.md](CHANGELOG.md) is updated
