### PR TITLE
Fix #298 -- create m2m when using `_bulk_create=True`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   remind:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       (github.actor != 'dependabot[bot]')

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on: [release]
 jobs:
   package:
     name: Build & verify package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       postgis:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fixed a bug with `seq` being passed a tz-aware start value [PR #353](https://github.com/model-bakers/model_bakery/pull/353)
 - [dev] Use official postgis docker image in CI [PR #355](https://github.com/model-bakers/model_bakery/pull/355)
+- Create m2m when using `_bulk_create=True` [PR #354](https://github.com/model-bakers/model_bakery/pull/354)
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -13,7 +13,7 @@ from typing import (
     overload,
 )
 
-import django
+from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.conf import settings
 from django.contrib import contenttypes
@@ -792,7 +792,7 @@ def bulk_create(baker: Baker[M], quantity: int, **kwargs) -> List[M]:
     created_entries = manager.bulk_create(entries)
     # bulk_create in Django < 4.0 does not return ids of created objects.
     #  drop this after 01 Apr 2024 (Django 3.2 LTS end of life)
-    if django.VERSION < (4, 0):
+    if DJANGO_VERSION < (4, 0):
         created_entries = manager.exclude(pk__in=existing_entries)
 
     # set many-to-many relations from kwargs

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -787,7 +787,11 @@ def bulk_create(baker: Baker[M], quantity: int, **kwargs) -> List[M]:
     else:
         manager = baker.model._base_manager
 
+    existing_entries = list(manager.values_list("pk", flat=True))
     created_entries = manager.bulk_create(entries)
+    # bulk_create in Django < 4.0 does not return ids of created objects
+    created_entries = manager.exclude(pk__in=existing_entries)
+
     # set many-to-many relations from kwargs
     for entry in created_entries:
         for field in baker.model._meta.many_to_many:

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -13,6 +13,7 @@ from typing import (
     overload,
 )
 
+import django
 from django.apps import apps
 from django.conf import settings
 from django.contrib import contenttypes
@@ -789,8 +790,10 @@ def bulk_create(baker: Baker[M], quantity: int, **kwargs) -> List[M]:
 
     existing_entries = list(manager.values_list("pk", flat=True))
     created_entries = manager.bulk_create(entries)
-    # bulk_create in Django < 4.0 does not return ids of created objects
-    created_entries = manager.exclude(pk__in=existing_entries)
+    # bulk_create in Django < 4.0 does not return ids of created objects.
+    #  drop this after 01 Apr 2024 (Django 3.2 LTS end of life)
+    if django.VERSION < (4, 0):
+        created_entries = manager.exclude(pk__in=existing_entries)
 
     # set many-to-many relations from kwargs
     for entry in created_entries:

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -3,6 +3,7 @@ import itertools
 from decimal import Decimal
 from unittest.mock import patch
 
+import django
 import pytest
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -151,17 +152,18 @@ class TestsBakerRepeatedCreatesSimpleModel(TestCase):
             assert all(p.name == "George Washington" for p in people)
 
     def test_make_quantity_respecting_bulk_create_parameter(self):
-        with self.assertNumQueries(3):
+        query_count = 2 if django.VERSION >= (4, 0) else 3
+        with self.assertNumQueries(query_count):
             baker.make(models.Person, _quantity=5, _bulk_create=True)
         assert models.Person.objects.count() == 5
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(query_count):
             people = baker.make(
                 models.Person, name="George Washington", _quantity=5, _bulk_create=True
             )
             assert all(p.name == "George Washington" for p in people)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(query_count):
             baker.make(models.NonStandardManager, _quantity=3, _bulk_create=True)
             assert getattr(models.NonStandardManager, "objects", None) is None
             assert (
@@ -362,30 +364,32 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert models.Person.objects.all().count() == 5
 
     def test_bulk_create_multiple_one_to_one(self):
-        with self.assertNumQueries(8):
+        query_count = 7 if django.VERSION >= (4, 0) else 8
+        with self.assertNumQueries(query_count):
             baker.make(models.LonelyPerson, _quantity=5, _bulk_create=True)
 
         assert models.LonelyPerson.objects.all().count() == 5
         assert models.Person.objects.all().count() == 5
 
     def test_chaining_bulk_create_reduces_query_count(self):
-        qtd = 5
-        with self.assertNumQueries(7):
-            baker.make(models.Person, _quantity=qtd, _bulk_create=True)
+        query_count = 5 if django.VERSION >= (4, 0) else 7
+        with self.assertNumQueries(query_count):
+            baker.make(models.Person, _quantity=5, _bulk_create=True)
             person_iter = models.Person.objects.all().iterator()
             baker.make(
                 models.LonelyPerson,
                 only_friend=person_iter,
-                _quantity=qtd,
+                _quantity=5,
                 _bulk_create=True,
             )
             # 2 bulk create and 1 select on Person
 
-        assert models.LonelyPerson.objects.all().count() == qtd
-        assert models.Person.objects.all().count() == qtd
+        assert models.LonelyPerson.objects.all().count() == 5
+        assert models.Person.objects.all().count() == 5
 
     def test_bulk_create_multiple_fk(self):
-        with self.assertNumQueries(8):
+        query_count = 7 if django.VERSION >= (4, 0) else 8
+        with self.assertNumQueries(query_count):
             baker.make(models.PaymentBill, _quantity=5, _bulk_create=True)
 
         assert models.PaymentBill.objects.all().count() == 5
@@ -1037,10 +1041,11 @@ class TestBakerMakeCanFetchInstanceFromDefaultManager:
 class TestCreateM2MWhenBulkCreate(TestCase):
     @pytest.mark.django_db
     def test_create(self):
-        with self.assertNumQueries(24):
+        query_count = 13 if django.VERSION >= (4, 0) else 14
+        with self.assertNumQueries(query_count):
             person = baker.make(models.Person)
             baker.make(
-                models.Classroom, students=[person], _quantity=20, _bulk_create=True
+                models.Classroom, students=[person], _quantity=10, _bulk_create=True
             )
         c1, c2 = models.Classroom.objects.all()[:2]
         assert list(c1.students.all()) == list(c2.students.all()) == [person]

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -3,8 +3,8 @@ import itertools
 from decimal import Decimal
 from unittest.mock import patch
 
-import django
 import pytest
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Manager
@@ -152,7 +152,7 @@ class TestsBakerRepeatedCreatesSimpleModel(TestCase):
             assert all(p.name == "George Washington" for p in people)
 
     def test_make_quantity_respecting_bulk_create_parameter(self):
-        query_count = 2 if django.VERSION >= (4, 0) else 3
+        query_count = 2 if DJANGO_VERSION >= (4, 0) else 3
         with self.assertNumQueries(query_count):
             baker.make(models.Person, _quantity=5, _bulk_create=True)
         assert models.Person.objects.count() == 5
@@ -364,7 +364,7 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert models.Person.objects.all().count() == 5
 
     def test_bulk_create_multiple_one_to_one(self):
-        query_count = 7 if django.VERSION >= (4, 0) else 8
+        query_count = 7 if DJANGO_VERSION >= (4, 0) else 8
         with self.assertNumQueries(query_count):
             baker.make(models.LonelyPerson, _quantity=5, _bulk_create=True)
 
@@ -372,7 +372,7 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert models.Person.objects.all().count() == 5
 
     def test_chaining_bulk_create_reduces_query_count(self):
-        query_count = 5 if django.VERSION >= (4, 0) else 7
+        query_count = 5 if DJANGO_VERSION >= (4, 0) else 7
         with self.assertNumQueries(query_count):
             baker.make(models.Person, _quantity=5, _bulk_create=True)
             person_iter = models.Person.objects.all().iterator()
@@ -388,7 +388,7 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert models.Person.objects.all().count() == 5
 
     def test_bulk_create_multiple_fk(self):
-        query_count = 7 if django.VERSION >= (4, 0) else 8
+        query_count = 7 if DJANGO_VERSION >= (4, 0) else 8
         with self.assertNumQueries(query_count):
             baker.make(models.PaymentBill, _quantity=5, _bulk_create=True)
 
@@ -1041,7 +1041,7 @@ class TestBakerMakeCanFetchInstanceFromDefaultManager:
 class TestCreateM2MWhenBulkCreate(TestCase):
     @pytest.mark.django_db
     def test_create(self):
-        query_count = 13 if django.VERSION >= (4, 0) else 14
+        query_count = 13 if DJANGO_VERSION >= (4, 0) else 14
         with self.assertNumQueries(query_count):
             person = baker.make(models.Person)
             baker.make(

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1037,7 +1037,7 @@ class TestBakerMakeCanFetchInstanceFromDefaultManager:
 class TestCreateM2MWhenBulkCreate(TestCase):
     @pytest.mark.django_db
     def test_create(self):
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(24):
             person = baker.make(models.Person)
             baker.make(
                 models.Classroom, students=[person], _quantity=20, _bulk_create=True

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1032,3 +1032,15 @@ class TestBakerMakeCanFetchInstanceFromDefaultManager:
             _from_manager="objects",
         )
         assert movie.title == movie.name
+
+
+class TestCreateM2MWhenBulkCreate(TestCase):
+    @pytest.mark.django_db
+    def test_create(self):
+        with self.assertNumQueries(22):
+            person = baker.make(models.Person)
+            baker.make(
+                models.Classroom, students=[person], _quantity=20, _bulk_create=True
+            )
+        c1, c2 = models.Classroom.objects.all()[:2]
+        assert list(c1.students.all()) == list(c2.students.all()) == [person]


### PR DESCRIPTION
**Describe the change**
Extending logic of `_save_related_objs` that was added in #206.
This is optimized because of `bulk_create` use on through model, but it is still quite heavy on queries.

I had to switch to Ubuntu 22 in CI to upgrade default SQLite version which supports returning pks in bulk create operations.


**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
