### PR TITLE
CI: Switch to Python 3.11 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: "pip"
-  directory: "/"
-  schedule:
-    interval: "monthly"
-  rebase-strategy: "auto"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "auto"
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,7 @@ name: Code Linter
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -13,11 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: PyPI release
 
-on: [release]
+on:
+  release:
+    types: [ published ]
 
 jobs:
   package:
@@ -11,13 +13,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
 
-      - name: Install Python dependencies
+      - name: Install dependencies
         run: python -m pip install --upgrade pip setuptools wheel twine
+
       - name: Build dist packages
         run: python setup.py sdist bdist_wheel
+
       - name: Upload packages
         run: python -m twine upload dist/*
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       PGPASSWORD: postgres
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3
@@ -49,5 +49,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade tox tox-gh-actions
+
       - name: Run tox targets for ${{ matrix.python-version }}
         run: python -m tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- [dev] Switch to Python 3.11 release in CI [#357](https://github.com/model-bakers/model_bakery/pull/357)
 
 ### Removed
 


### PR DESCRIPTION
`model-bakery` was already supporting 3.11-dev, now we can switch to released 3.11.
PR also includes a couple of linting changes.
