### PR TITLE
Fix CI for tox 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox tox-py
+          python -m pip install --upgrade tox
 
       - name: Run tox targets for ${{ matrix.python-version }}
-        run: tox --py current
+        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
 
   linters:
     name: Linters


### PR DESCRIPTION
**Describe the change**

tox 4 was released yesterday, and tox-py is incompatible with it. We can replace it with a one-liner as documented: https://github.com/adamchainz/tox-py#installation

**PR Checklist**
- [x] Change is covered with tests
- [n/a] [CHANGELOG.md](CHANGELOG.md) is updated
