### PR TITLE
Drop support for `FloatRangeField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
+- dropped support for `FloatRangeField` as it was removed in Django 3.1
 
 ## [1.10.2](https://pypi.org/project/model-bakery/1.10.2/)
 

--- a/docs/source/how_bakery_behaves.rst
+++ b/docs/source/how_bakery_behaves.rst
@@ -49,7 +49,7 @@ Currently supported fields
 * ``FileField``, ``ImageField``
 * ``JSONField``, ``ArrayField``, ``HStoreField``
 * ``CICharField``, ``CIEmailField``, ``CITextField``
-* ``DecimalRangeField``, ``IntegerRangeField``, ``BigIntegerRangeField``, ``FloatRangeField``, ``DateRangeField``, ``DateTimeRangeField``
+* ``DecimalRangeField``, ``IntegerRangeField``, ``BigIntegerRangeField``, ``DateRangeField``, ``DateTimeRangeField``
 
 Require ``django.contrib.gis`` in ``INSTALLED_APPS``:
 

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -62,7 +62,7 @@ except ImportError:
     ArrayField = None
 
 try:
-    # Deprecated since Django 3.1
+    # Deprecated since Django 3.1, removed in Django 4.0
     # PostgreSQL-specific field (only available when psycopg2 is installed)
     from django.contrib.postgres.fields import JSONField as PostgresJSONField
 except ImportError:
@@ -87,7 +87,7 @@ except ImportError:
     CITextField = None
 
 try:
-    # Deprecated since Django 3.1
+    # Deprecated since Django 3.1, removed in Django 4.0
     from django.db.models import NullBooleanField
 except ImportError:
     NullBooleanField = None
@@ -108,12 +108,6 @@ except ImportError:
     DateTimeRangeField = None
     DecimalRangeField = None
     IntegerRangeField = None
-
-try:
-    # Deprecated since Django 2.2
-    from django.contrib.postgres.fields.ranges import FloatRangeField
-except ImportError:
-    FloatRangeField = None
 
 
 def _make_integer_gen_by_range(field_type: Any) -> Callable:
@@ -184,8 +178,6 @@ if IntegerRangeField:
     default_mapping[IntegerRangeField] = random_gen.gen_pg_numbers_range(int)
 if BigIntegerRangeField:
     default_mapping[BigIntegerRangeField] = random_gen.gen_pg_numbers_range(int)
-if FloatRangeField:
-    default_mapping[FloatRangeField] = random_gen.gen_pg_numbers_range(float)
 if DateRangeField:
     default_mapping[DateRangeField] = random_gen.gen_date_range
 if DateTimeRangeField:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,6 @@ pip-tools==6.12.1
 pre-commit==2.21.0
 psycopg2-binary==2.9.5
 pycodestyle==2.10.0
-pydocstyle==6.3.0
+pydocstyle[toml]==6.3.0
 pytest==7.2.1
 pytest-django==4.5.2

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -1,7 +1,7 @@
-#######################################
-# TESTING PURPOSE ONLY MODELS!!       #
-# DO NOT ADD THE APP TO INSTALLED_APPS#
-#######################################
+########################################
+# TESTING PURPOSE ONLY MODELS!!        #
+# DO NOT ADD THE APP TO INSTALLED_APPS #
+########################################
 import datetime
 from decimal import Decimal
 from tempfile import gettempdir
@@ -23,7 +23,7 @@ from .fields import (
     FakeListField,
 )
 
-# check whether or not PIL is installed
+# check whether PIL is installed
 try:
     from PIL import ImageFile as PilImageFile  # NoQA
 except ImportError:
@@ -111,6 +111,7 @@ class Person(models.Model):
             BigIntegerRangeField,
             DateRangeField,
             DateTimeRangeField,
+            DecimalRangeField,
             IntegerRangeField,
         )
 
@@ -125,26 +126,9 @@ class Person(models.Model):
             bigint_range = BigIntegerRangeField()
             date_range = DateRangeField()
             datetime_range = DateTimeRangeField()
-    except ImportError:
-        # Skip PostgreSQL-related fields
-        pass
-
-    try:
-        from django.contrib.postgres.fields.ranges import FloatRangeField
-
-        if settings.USING_POSTGRES:
-            float_range = FloatRangeField()
-    except ImportError:
-        # Django version greater or equal than 3.1
-        pass
-
-    try:
-        from django.contrib.postgres.fields.ranges import DecimalRangeField
-
-        if settings.USING_POSTGRES:
             decimal_range = DecimalRangeField()
     except ImportError:
-        # Django version lower than 2.2
+        # Skip PostgreSQL-related fields
         pass
 
     if BAKER_GIS:

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -38,6 +38,7 @@ try:
         BigIntegerRangeField,
         DateRangeField,
         DateTimeRangeField,
+        DecimalRangeField,
         IntegerRangeField,
     )
 except ImportError:
@@ -51,14 +52,6 @@ except ImportError:
     BigIntegerRangeField = None
     DateRangeField = None
     DateTimeRangeField = None
-
-try:
-    from django.contrib.postgres.fields.ranges import FloatRangeField
-except ImportError:
-    FloatRangeField = None
-try:
-    from django.contrib.postgres.fields.ranges import DecimalRangeField
-except ImportError:
     DecimalRangeField = None
 
 
@@ -506,20 +499,6 @@ class TestCIStringFieldsFilling:
         assert isinstance(person.bigint_range.lower, int)
         assert isinstance(person.bigint_range.upper, int)
         assert person.bigint_range.lower < person.bigint_range.upper
-
-    @pytest.mark.skipif(
-        FloatRangeField is None,
-        reason="FloatRangeField is deprecated since Django 2.2",
-    )
-    def test_filling_float_range_field(self, person):
-        from psycopg2._range import NumericRange
-
-        float_range_field = models.Person._meta.get_field("float_range")
-        assert isinstance(float_range_field, FloatRangeField)
-        assert isinstance(person.float_range, NumericRange)
-        assert isinstance(person.float_range.lower, float)
-        assert isinstance(person.float_range.upper, float)
-        assert person.float_range.lower < person.float_range.upper
 
     def test_filling_date_range_field(self, person):
         from psycopg2.extras import DateRange


### PR DESCRIPTION
It was removed in Django 3.1 and we support Django 3.2+ only.
