### PR TITLE
Allow generating strings when max_length=None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+- Add support for CharField with max_length=None
 
 ### Changed
 

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -109,11 +109,8 @@ def gen_time() -> time:
     return now().time()
 
 
-def gen_string(max_length: int) -> str:
+def gen_string(max_length: int = MAX_LENGTH) -> str:
     return str("".join(choice(string.ascii_letters) for _ in range(max_length)))
-
-
-gen_string.required = ["max_length"]  # type: ignore[attr-defined]
 
 
 def gen_slug(max_length: int) -> str:

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -109,9 +109,16 @@ def gen_time() -> time:
     return now().time()
 
 
-def gen_string(max_length: int = MAX_LENGTH) -> str:
+def gen_string(max_length: int) -> str:
     return str("".join(choice(string.ascii_letters) for _ in range(max_length)))
 
+def _gen_string_get_max_length(field: Field) -> Tuple[str, int]:
+    max_length = getattr(field, "max_length", None)
+    if max_length is None:
+        max_length = MAX_LENGTH
+    return "max_length", max_length
+
+gen_string.required = [_gen_string_get_max_length] # type: ignore[attr-defined]
 
 def gen_slug(max_length: int) -> str:
     valid_chars = string.ascii_letters + string.digits + "_-"

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -118,7 +118,7 @@ def _gen_string_get_max_length(field: Field) -> Tuple[str, int]:
         max_length = MAX_LENGTH
     return "max_length", max_length
 
-gen_string.required = [_gen_string_get_max_length] # type: ignore[attr-defined]
+gen_string.required = [_gen_string_get_max_length]  # type: ignore[attr-defined]
 
 def gen_slug(max_length: int) -> str:
     valid_chars = string.ascii_letters + string.digits + "_-"

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -112,13 +112,16 @@ def gen_time() -> time:
 def gen_string(max_length: int) -> str:
     return str("".join(choice(string.ascii_letters) for _ in range(max_length)))
 
+
 def _gen_string_get_max_length(field: Field) -> Tuple[str, int]:
     max_length = getattr(field, "max_length", None)
     if max_length is None:
         max_length = MAX_LENGTH
     return "max_length", max_length
 
+
 gen_string.required = [_gen_string_get_max_length]  # type: ignore[attr-defined]
+
 
 def gen_slug(max_length: int) -> str:
     valid_chars = string.ascii_letters + string.digits + "_-"

--- a/postgres-docker
+++ b/postgres-docker
@@ -150,7 +150,7 @@ fi
 # Start postgres container
 echo "Starting '${CONTAINER_NAME}'..."
 
-$DOCKER run --rm --name ${CONTAINER_NAME} -e POSTGRES_HOST_AUTH_METHOD=trust -p ${PORT}:5432 -d postgis/postgis:11-3.0
+$DOCKER run --rm --name ${CONTAINER_NAME} -e POSTGRES_HOST_AUTH_METHOD=trust -p ${PORT}:5432 -d postgis/postgis:12-3.3
 
 # Wait a few seconds so the DB container can start up
 echo "Waiting for DB container..."

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -6,6 +6,7 @@ import datetime
 from decimal import Decimal
 from tempfile import gettempdir
 
+import django
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -116,7 +117,8 @@ class Person(models.Model):
         )
 
         if settings.USING_POSTGRES:
-            long_name = models.CharField()
+            if django.VERSION >= (4, 2):
+                long_name = models.CharField()
             acquaintances = ArrayField(models.IntegerField())
             postgres_data = PostgresJSONField()
             hstore_data = HStoreField()

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -116,6 +116,7 @@ class Person(models.Model):
         )
 
         if settings.USING_POSTGRES:
+            long_name = models.CharField()
             acquaintances = ArrayField(models.IntegerField())
             postgres_data = PostgresJSONField()
             hstore_data = HStoreField()


### PR DESCRIPTION
**Describe the change**
Fixes #407

Allows generating strings when `max_length=None`.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
