### PR TITLE
fix: seq function with start=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fix utils.seq with start=0
 
 ### Removed
 

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -94,7 +94,9 @@ def seq(value, increment_by=1, start=None, suffix=None):
             else:
                 yield series_date
     else:
-        for n in itertools.count(start or increment_by, increment_by):
+        for n in itertools.count(
+            increment_by if start is None else start, increment_by
+        ):
             if suffix:
                 yield value + str(n) + suffix
             else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,6 +116,12 @@ class TestSeq:
         assert next(sequence) == pytest.approx(4.83)
         assert next(sequence) == pytest.approx(6.63)
 
+    def test_numbers_start_from_zero(self):
+        sequence = seq(0, start=0)
+        assert next(sequence) == 0
+        assert next(sequence) == 1
+        assert next(sequence) == 2
+
     def test_numbers_with_suffix(self):
         with pytest.raises(TypeError) as exc:
             next(seq(1, suffix="iamnotanumber"))


### PR DESCRIPTION
**Describe the change**
Fixes #415 

utils.seq(0, start=0) should start from 0

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
