### PR TITLE
:sparkles: Adds global seeding to baker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+- Add support for global seeding to baker random generation
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,6 @@ lint:
 	@isort .
 	@flake8 .
 	@pydocstyle .
+	@mypy model_bakery
 
 .PHONY: test release

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -59,6 +59,10 @@ def _valid_quantity(quantity: Optional[Union[str, int]]) -> bool:
     return quantity is not None and (not isinstance(quantity, int) or quantity < 1)
 
 
+def seed(seed: Union[int, float, str, bytes, bytearray, None]) -> None:
+    Baker.seed(seed)
+
+
 @overload
 def make(
     _model: Union[str, Type[M]],
@@ -315,9 +319,16 @@ class Baker(Generic[M]):
     attr_mapping: Dict[str, Any] = {}
     type_mapping: Dict = {}
 
+    _global_seed: Union[int, float, str, bytes, bytearray, None] = None
+
     # Note: we're using one finder for all Baker instances to avoid
     # rebuilding the model cache for every make_* or prepare_* call.
     finder = ModelFinder()
+
+    @classmethod
+    def seed(cls, seed: Union[int, float, str, bytes, bytearray, None]) -> None:
+        random_gen.baker_random.seed(seed)
+        cls._global_seed = seed
 
     @classmethod
     def create(

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -321,7 +321,7 @@ class Baker(Generic[M]):
     attr_mapping: Dict[str, Any] = {}
     type_mapping: Dict = {}
 
-    _global_seed: Union[int, float, str, bytes, bytearray, None] = SENTINEL
+    _global_seed: Union[object, int, float, str, bytes, bytearray, None] = SENTINEL
 
     # Note: we're using one finder for all Baker instances to avoid
     # rebuilding the model cache for every make_* or prepare_* call.

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -316,10 +316,12 @@ def _custom_baker_class() -> Optional[Type]:
 
 
 class Baker(Generic[M]):
+    SENTINEL = object()
+
     attr_mapping: Dict[str, Any] = {}
     type_mapping: Dict = {}
 
-    _global_seed: Union[int, float, str, bytes, bytearray, None] = None
+    _global_seed: Union[int, float, str, bytes, bytearray, None] = SENTINEL
 
     # Note: we're using one finder for all Baker instances to avoid
     # rebuilding the model cache for every make_* or prepare_* call.

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1049,3 +1049,15 @@ class TestCreateM2MWhenBulkCreate(TestCase):
             )
         c1, c2 = models.Classroom.objects.all()[:2]
         assert list(c1.students.all()) == list(c2.students.all()) == [person]
+
+
+class TestBakerSeeded(TestCase):
+    @pytest.mark.django_db
+    def test_seed(self):
+        old_state = random_gen.baker_random.getstate()
+
+        baker.seed(1)
+        assert baker.Baker._global_seed == 1
+        assert random_gen.gen_integer() == 55195912693
+
+        random_gen.baker_random.setstate(old_state)

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1061,3 +1061,8 @@ class TestBakerSeeded(TestCase):
         assert random_gen.gen_integer() == 55195912693
 
         random_gen.baker_random.setstate(old_state)
+        baker.Baker._global_seed = baker.Baker.SENTINEL
+
+    @pytest.mark.django_db
+    def test_unseeded(self):
+        assert baker.Baker._global_seed is baker.Baker.SENTINEL

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1051,17 +1051,19 @@ class TestCreateM2MWhenBulkCreate(TestCase):
         assert list(c1.students.all()) == list(c2.students.all()) == [person]
 
 
-class TestBakerSeeded(TestCase):
-    @pytest.mark.django_db
-    def test_seed(self):
+class TestBakerSeeded:
+    @pytest.fixture()
+    def reset_seed(self):
         old_state = random_gen.baker_random.getstate()
+        yield
+        random_gen.baker_random.setstate(old_state)
+        baker.Baker._global_seed = baker.Baker.SENTINEL
 
+    @pytest.mark.django_db
+    def test_seed(self, reset_seed):
         baker.seed(1)
         assert baker.Baker._global_seed == 1
         assert random_gen.gen_integer() == 55195912693
-
-        random_gen.baker_random.setstate(old_state)
-        baker.Baker._global_seed = baker.Baker.SENTINEL
 
     @pytest.mark.django_db
     def test_unseeded(self):

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 from os.path import abspath
 from tempfile import gettempdir
 
-import django
 import pytest
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
**Describe the change**
Adds baker random generation seeding. This allows for repeatable random generation within baker fixtures independently of other packages/system random. Future support could be added to seed individual instances of baker (like [faker](https://github.com/joke2k/faker) does).

After merging this a follow up PR could add baker seeding to [pytest-randomly](https://github.com/pytest-dev/pytest-randomly).

Re issue https://github.com/model-bakers/model_bakery/issues/380.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
