### PR TITLE
perf: improve performance of `Baker.get_fields()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [dev] Test coverage report
 
 ### Changed
+- Improved performance of `Baker.get_fields()`
 - [dev] Cleanup Sphinx documentation config
 
 ### Removed

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -412,12 +412,10 @@ class Baker(Generic[M]):
         params.update(attrs)
         return self._make(**params)
 
-    def get_fields(self) -> List[Any]:
-        return [
-            f
-            for f in self.model._meta.get_fields()
-            if f not in self.model._meta.related_objects
-        ]
+    def get_fields(self) -> Set[Any]:
+        return set(self.model._meta.get_fields()) - set(
+            self.model._meta.related_objects
+        )
 
     def _make(  # noqa: C901
         self,

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -8,6 +8,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Type,
     Union,
     cast,


### PR DESCRIPTION
**Describe the change**
https://github.com/model-bakers/model_bakery/pull/352 was meant to be a cosmetic change which introduced a performance regression.

This PR reduces the time complexity of `get_fields()` from O(n*m) to O(n).

I have a project of significant size (over 50k tests), this change reduces the total runtime of the test suite by ~200% back to what we saw before release 1.8.0.
I also tried other approaches, for example using `filter` or turning this into a cached property but these didn't achieve a better result.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
