### PR TITLE
Bump pre-commit version, fix ruff caller

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: debug-statements
@@ -13,6 +13,7 @@ repos:
         name: ruff
         entry: ruff
         language: system
+        args: [ --fix, --exit-non-zero-on-fix ]
         types:
           - python
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - [dev] Cleanup Sphinx documentation config
+- [dev] Update `pre-commit` config
 
 ### Removed
 


### PR DESCRIPTION
Previously, pre-commit was just showing ruff fixes, but not applying them, this changes the behaviour to fix and exit with error code.