### PR TITLE
CI: remove hard requirement on linters for tests to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
 
   tests:
     name: Python ${{ matrix.python-version }}
-    needs:
-      - linters
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved performance of `Baker.get_fields()`
 - [dev] Cleanup Sphinx documentation config
 - [dev] Update `pre-commit` config
+- [dev] CI: remove hard requirement on linters for tests to run
 
 ### Removed
 


### PR DESCRIPTION
**Describe the change**
Noted, that failing linters are preventing tests to run, which can block/slow down contributors.

**PR Checklist**
- [x] Change is covered with tests or tests are not needed
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
