### PR TITLE
refactor/perf: Eliminate redundant string casting in random_gen utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Remove unnecessary casting to string methods random_gen.gen_slug and random_gen.gen_string
 
 ### Removed
 

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -112,9 +112,7 @@ def gen_time() -> time:
 
 
 def gen_string(max_length: int) -> str:
-    return str(
-        "".join(baker_random.choice(string.ascii_letters) for _ in range(max_length))
-    )
+    return "".join(baker_random.choice(string.ascii_letters) for _ in range(max_length))
 
 
 def _gen_string_get_max_length(field: Field) -> Tuple[str, int]:
@@ -129,7 +127,7 @@ gen_string.required = [_gen_string_get_max_length]  # type: ignore[attr-defined]
 
 def gen_slug(max_length: int) -> str:
     valid_chars = string.ascii_letters + string.digits + "_-"
-    return str("".join(baker_random.choice(valid_chars) for _ in range(max_length)))
+    return "".join(baker_random.choice(valid_chars) for _ in range(max_length))
 
 
 gen_slug.required = ["max_length"]  # type: ignore[attr-defined]


### PR DESCRIPTION
**Describe the change**
In the random_gen utility, the gen_slug and gen_string methods already return string values, rendering the additional casting operations unnecessary.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
