### PR TITLE
Drop Django 4.1 support (reached end of life)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
+- Drop Django 4.1 support (reached end of life)
 
 ## [1.17.0](https://pypi.org/project/model-bakery/1.17.0/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 env_list =
-    py38-django{32,41,42}-{postgresql,sqlite}
-    py39-django{32,41,42}-{postgresql,sqlite}
-    py310-django{32,41,42,50}-{postgresql,sqlite}
-    py311-django{32,41,42,50}-{postgresql,sqlite}
+    py38-django{32,42}-{postgresql,sqlite}
+    py39-django{32,42}-{postgresql,sqlite}
+    py310-django{32,42,50}-{postgresql,sqlite}
+    py311-django{32,42,50}-{postgresql,sqlite}
     py311-django{42,50}-{postgresql-psycopg3}
     py312-django{42,50}-{postgresql-psycopg3}
 
@@ -25,7 +25,6 @@ deps =
     pytest
     pytest-django
     django32: Django==3.2
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5
     django50: Django>=5.0,<5.1
     postgresql: psycopg2-binary


### PR DESCRIPTION
**Describe the change**
https://www.djangoproject.com/download/#supported-versions
https://endoflife.date/django

**PR Checklist**
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
