### PR TITLE
Fix #265 -- drop hard dependency on `contenttypes` framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add Django 5.0 support
 
 ### Changed
+- Allow baking without `contenttypes` framework
 
 ### Removed
 - Drop Django 3.2 and 4.1 support (reached end of life)

--- a/model_bakery/content_types.py
+++ b/model_bakery/content_types.py
@@ -1,0 +1,14 @@
+from django.apps import apps
+
+BAKER_CONTENTTYPES = apps.is_installed("django.contrib.contenttypes")
+
+default_contenttypes_mapping = {}
+
+__all__ = ["BAKER_CONTENTTYPES", "default_contenttypes_mapping"]
+
+if BAKER_CONTENTTYPES:
+    from django.contrib.contenttypes.models import ContentType
+
+    from . import random_gen
+
+    default_contenttypes_mapping[ContentType] = random_gen.gen_content_type

--- a/model_bakery/generators.py
+++ b/model_bakery/generators.py
@@ -150,14 +150,12 @@ if DateTimeRangeField:
 
 
 def get_type_mapping() -> Dict[Type, Callable]:
-    from django.contrib.contenttypes.models import ContentType
-
+    from .content_types import default_contenttypes_mapping
     from .gis import default_gis_mapping
 
     mapping = default_mapping.copy()
-    mapping[ContentType] = random_gen.gen_content_type
+    mapping.update(default_contenttypes_mapping)
     mapping.update(default_gis_mapping)
-
     return mapping.copy()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,17 @@ from django.conf import settings
 
 def pytest_configure():
     test_db = os.environ.get("TEST_DB", "sqlite")
+    use_contenttypes = os.environ.get("USE_CONTENTTYPES", False)
     installed_apps = [
-        "django.contrib.contenttypes",
-        "django.contrib.auth",
         "tests.generic",
         "tests.ambiguous",
         "tests.ambiguous2",
     ]
+
+    if use_contenttypes:
+        installed_apps.append("django.contrib.contenttypes")
+        # auth app depends on contenttypes
+        installed_apps.append("django.contrib.auth")
 
     using_postgres_flag = False
     postgis_version = ()
@@ -76,11 +80,11 @@ def pytest_configure():
         POSTGIS_VERSION=postgis_version,
     )
 
+    django.setup()
+
     from model_bakery import baker
 
     def gen_same_text():
         return "always the same text"
 
     baker.generators.add("tests.generic.fields.CustomFieldViaSettings", gen_same_text)
-
-    django.setup()

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -3,8 +3,8 @@ import itertools
 from decimal import Decimal
 from unittest.mock import patch
 
+from django.apps import apps
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import Manager
 from django.db.models.signals import m2m_changed
 from django.test import TestCase, override_settings
@@ -12,7 +12,7 @@ from django.test import TestCase, override_settings
 import pytest
 
 from model_bakery import baker, random_gen
-from model_bakery.baker import MAX_MANY_QUANTITY
+from model_bakery.baker import BAKER_CONTENTTYPES, MAX_MANY_QUANTITY
 from model_bakery.exceptions import (
     AmbiguousModelName,
     InvalidQuantityException,
@@ -232,6 +232,11 @@ class TestsBakerRepeatedCreatesSimpleModel(TestCase):
         assert num_2.value == 2
         assert num_3.value == 3
 
+    # skip if auth app is not installed
+    @pytest.mark.skipif(
+        not apps.is_installed("django.contrib.auth"),
+        reason="Django auth app is not installed",
+    )
     def test_generators_work_with_user_model(self):
         from django.contrib.auth import get_user_model
 
@@ -602,6 +607,9 @@ class TestHandlingUnsupportedModels:
             assert "field unsupported_field" in repr(e)
 
 
+@pytest.mark.skipif(
+    not BAKER_CONTENTTYPES, reason="Django contenttypes framework is not installed"
+)
 @pytest.mark.django_db
 class TestHandlingModelsWithGenericRelationFields:
     def test_create_model_with_generic_relation(self):
@@ -609,16 +617,26 @@ class TestHandlingModelsWithGenericRelationFields:
         assert isinstance(dummy, models.DummyGenericRelationModel)
 
 
+@pytest.mark.skipif(
+    not BAKER_CONTENTTYPES, reason="Django contenttypes framework is not installed"
+)
 @pytest.mark.django_db
 class TestHandlingContentTypeField:
     def test_create_model_with_contenttype_field(self):
+        from django.contrib.contenttypes.models import ContentType
+
         dummy = baker.make(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
         assert isinstance(dummy.content_type, ContentType)
 
 
+@pytest.mark.skipif(
+    not BAKER_CONTENTTYPES, reason="Django contenttypes framework is not installed"
+)
 class TestHandlingContentTypeFieldNoQueries:
     def test_create_model_with_contenttype_field(self):
+        from django.contrib.contenttypes.models import ContentType
+
         # Clear ContentType's internal cache so that it *will* try to connect to
         # the database to fetch the corresponding ContentType model for
         # a randomly chosen model.

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -5,7 +5,6 @@ from os.path import abspath
 from tempfile import gettempdir
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.core.validators import (
     validate_ipv4_address,
     validate_ipv6_address,
@@ -17,6 +16,7 @@ from django.db.models import FileField, ImageField, fields
 import pytest
 
 from model_bakery import baker
+from model_bakery.content_types import BAKER_CONTENTTYPES
 from model_bakery.gis import BAKER_GIS
 from model_bakery.random_gen import gen_related
 from tests.generic import generators, models
@@ -271,9 +271,15 @@ class TestFillingIPAddressField:
             validate_ipv46_address(obj.ipv46_field)
 
 
+# skipif
+@pytest.mark.skipif(
+    not BAKER_CONTENTTYPES, reason="Django contenttypes framework is not installed"
+)
 @pytest.mark.django_db
 class TestFillingGenericForeignKeyField:
     def test_filling_content_type_field(self):
+        from django.contrib.contenttypes.models import ContentType
+
         dummy = baker.make(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy.content_type, ContentType)
         assert dummy.content_type.model_class() is not None
@@ -285,6 +291,8 @@ class TestFillingGenericForeignKeyField:
         Otherwise, calling ``next()`` when a GFK is in ``iterator_attrs``
         would be bypassed.
         """
+        from django.contrib.contenttypes.models import ContentType
+
         objects = baker.make(models.Profile, _quantity=2)
         dummies = baker.make(
             models.DummyGenericForeignKeyModel,
@@ -579,7 +587,6 @@ class TestGisFieldsFilling:
         assert geom.valid is True, geom.valid_reason
 
     def test_fill_PointField_valid(self, person):
-        print(BAKER_GIS)
         self.assertGeomValid(person.point)
 
     def test_fill_LineStringField_valid(self, person):

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ env_list =
     py{38,39}-django{42}-{postgresql,sqlite}
     py{310,311}-django{42,50}-{postgresql,sqlite}
     py{311,312}-django{42,50}-{postgresql-psycopg3}
+    py312-django50-{postgresql-contenttypes}
 
 [testenv]
 package = wheel
@@ -14,6 +15,7 @@ setenv =
     postgresql-psycopg3: TEST_DB=postgis
     postgresql-psycopg3: PGUSER=postgres
     postgresql-psycopg3: PGPASSWORD=postgres
+    postgresql-contenttypes: USE_CONTENTTYPES=True
     sqlite: TEST_DB=sqlite
     sqlite: USE_TZ=True
 deps =


### PR DESCRIPTION
**Describe the change**

As mentioned in #265 - we are not hard-depending on `contenttypes` framework, so we need to be able to bake without it.
It is a bit tricky as there are multiple places, where we are using `contenttypes` framework and `auth` framework (which depends on `contenttypes`), however nothing is impossible.


**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated
