### PR TITLE
Replace expensive count() with cheap exists()

### DIFF
--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -52,7 +52,7 @@ class Recipe(Generic[M]):
                     m = finder.get_model(self._model)
                 else:
                     m = self._model
-                if k not in self._iterator_backups or m.objects.count() == 0:
+                if k not in self._iterator_backups or not m.objects.exists():
                     self._iterator_backups[k] = itertools.tee(
                         self._iterator_backups.get(k, [v])[0]
                     )


### PR DESCRIPTION
Heyo, hopefully an easy one. We are using model bakery in a setting where the DB can have millions of rows and counting the table just for checking, if any entry exists is overkill. The easy solution: only check for existence.