### PR TITLE
Fix #483 -- Add Django 5.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+- Add Django 5.1 support
 
 ### Changed
 - Fix support of GenericForeignKey fields in combination with `_fill_optional`

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -15,6 +15,7 @@ from typing import (
     overload,
 )
 
+from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.conf import settings
 from django.db.models import (

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -15,7 +15,6 @@ from typing import (
     overload,
 )
 
-from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.conf import settings
 from django.db.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 env_list =
     py{38,39}-django{42}-{postgresql,sqlite}
-    py{310,311}-django{42,50}-{postgresql,sqlite}
-    py{311,312}-django{42,50}-{postgresql-psycopg3}
-    py312-django50-{postgresql-contenttypes}
+    py{310,311}-django{42,50,51}-{postgresql,sqlite}
+    py{311,312}-django{42,50,51}-{postgresql-psycopg3}
+    py312-django{50,51}-{postgresql-contenttypes}
 
 [testenv]
 package = wheel
@@ -25,6 +25,7 @@ deps =
     pytest-django
     django42: Django>=4.2,<5
     django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
     postgresql: psycopg2-binary
     postgresql-psycopg3: psycopg
 commands =


### PR DESCRIPTION
**Describe the change**
[Django 5.1 was released](https://docs.djangoproject.com/en/5.1/releases/5.1/).

<strike>
Amongst the changes, there is [a signature change of a generic foreign key](https://github.com/django/django/commit/6002df06713cb0a7050432263527a25754190c27), which needs to be covered.
</strike>

Okay, I figured the issue, it was an old bug described in https://github.com/model-bakers/model_bakery/issues/416. Now I finally understood the cause and provided a fix. And there is no changes in Django 5.1 that should be addressed separately in order to provide support.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed
