### PR TITLE
Fix #488 -- Align GFK and content type fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Align GFK and content type fields generation
 
 ### Removed
 

--- a/model_bakery/content_types.py
+++ b/model_bakery/content_types.py
@@ -7,11 +7,8 @@ default_contenttypes_mapping = {}
 __all__ = ["BAKER_CONTENTTYPES", "default_contenttypes_mapping"]
 
 if BAKER_CONTENTTYPES:
-    from django.contrib.contenttypes.fields import GenericForeignKey
     from django.contrib.contenttypes.models import ContentType
 
     from . import random_gen
 
     default_contenttypes_mapping[ContentType] = random_gen.gen_content_type
-    # a small hack to generate random object for GenericForeignKey
-    default_contenttypes_mapping[GenericForeignKey] = random_gen.gen_content_type

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -284,6 +284,16 @@ class TestFillingGenericForeignKeyField:
         assert isinstance(dummy.content_type, ContentType)
         assert dummy.content_type.model_class() is not None
 
+    def test_filling_from_content_object(self):
+        from django.contrib.contenttypes.models import ContentType
+
+        dummy = baker.make(
+            models.DummyGenericForeignKeyModel,
+            content_object=baker.make(models.Profile),
+        )
+        assert dummy.content_type == ContentType.objects.get_for_model(models.Profile)
+        assert dummy.object_id == models.Profile.objects.get().pk
+
     def test_iteratively_filling_generic_foreign_key_field(self):
         """
         Ensures private_fields are included in ``Baker.get_fields()``.


### PR DESCRIPTION
**Describe the change**
Replace a hacky workaround from https://github.com/model-bakers/model_bakery/commit/0b4cfa7fe804bd74836aa3dff8141fbe24da500f#diff-7aca726c4b3af089805b51a56736cde676621ea8b404f024d8e51d879677ee09R17 with proper GFK field handling.
So now, the content type and object id should be filled from the provided content object.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed
