### PR TITLE
Do not handle GFK fields when the object is None

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -698,6 +698,8 @@ class Baker(Generic[M]):
             content_type_field = data["content_type_field"]
             object_id_field = data["object_id_field"]
             value = data["value"]
+            if value is None:
+                continue
             if is_iterator(value):
                 value = next(value)
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -277,14 +277,14 @@ class TestFillingIPAddressField:
 )
 @pytest.mark.django_db
 class TestFillingGenericForeignKeyField:
-    def test_filling_content_type_field(self):
+    def test_content_type_field(self):
         from django.contrib.contenttypes.models import ContentType
 
         dummy = baker.make(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy.content_type, ContentType)
         assert dummy.content_type.model_class() is not None
 
-    def test_filling_from_content_object(self):
+    def test_with_content_object(self):
         from django.contrib.contenttypes.models import ContentType
 
         profile = baker.make(models.Profile)
@@ -296,7 +296,14 @@ class TestFillingGenericForeignKeyField:
         assert dummy.content_type == ContentType.objects.get_for_model(models.Profile)
         assert dummy.object_id == profile.pk
 
-    def test_filling_generic_foreign_key_field_with_prepare(self):
+    def test_with_content_object_none(self):
+        dummy = baker.make(
+            models.DummyGenericForeignKeyModel,
+            content_object=None,
+        )
+        assert dummy.content_object is None
+
+    def test_with_prepare(self):
         from django.contrib.contenttypes.models import ContentType
 
         profile = baker.prepare(models.Profile, id=1)
@@ -308,7 +315,7 @@ class TestFillingGenericForeignKeyField:
         assert dummy.content_type == ContentType.objects.get_for_model(models.Profile)
         assert dummy.object_id == profile.pk == 1
 
-    def test_iteratively_filling_generic_foreign_key_field(self):
+    def test_with_iter(self):
         """
         Ensures private_fields are included in ``Baker.get_fields()``.
 


### PR DESCRIPTION
**Describe the change**
A clear and concise description of what the change is.

**PR Checklist**
- [x] Change is covered with tests
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated if needed
