### PR TITLE
Allow None value for generic foreign keys within iterators

### DIFF
--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -698,10 +698,10 @@ class Baker(Generic[M]):
             content_type_field = data["content_type_field"]
             object_id_field = data["object_id_field"]
             value = data["value"]
-            if value is None:
-                continue
             if is_iterator(value):
                 value = next(value)
+            if value is None:
+                continue
 
             setattr(instance, field_name, value)
             setattr(

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -341,6 +341,24 @@ class TestFillingGenericForeignKeyField:
         assert dummies[1].content_type == expected_content_type
         assert dummies[1].object_id == objects[1].pk
 
+    def test_with_none_in_iter(self):
+        from django.contrib.contenttypes.models import ContentType
+
+        profile = baker.make(models.Profile)
+        dummies = baker.make(
+            models.DummyGenericForeignKeyModel,
+            content_object=iter((None, profile)),
+            _quantity=2,
+        )
+
+        expected_content_type = ContentType.objects.get_for_model(models.Profile)
+
+        assert dummies[0].content_object is None
+
+        assert dummies[1].content_object == profile
+        assert dummies[1].content_type == expected_content_type
+        assert dummies[1].object_id == profile.pk
+
     def test_with_fill_optional(self):
         from django.contrib.contenttypes.models import ContentType
 


### PR DESCRIPTION
**Describe the change**
Allows `None` within iterators for generic foreign keys. The test also confirms that `next` is called on the iterator.

**PR Checklist**
- [x] Change is covered with tests
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated if needed
