### PR TITLE
Fix #498 -- Reset GFK fields when content object is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Reset `content_type` and `object_id` fields when the content object is `None`
 
 ### Removed
 

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -295,6 +295,16 @@ if BAKER_CONTENTTYPES:
     class DummyGenericRelationModel(models.Model):
         relation = GenericRelation(DummyGenericForeignKeyModel)
 
+    class GenericForeignKeyModelWithOptionalData(models.Model):
+        content_type = models.ForeignKey(
+            contenttypes.ContentType, on_delete=models.CASCADE, blank=True, null=True
+        )
+        object_id = models.PositiveIntegerField(blank=True, null=True)
+        content_object = GenericForeignKey("content_type", "object_id")
+
+    class GenericRelationModelWithOptionalData(models.Model):
+        relation = GenericRelation(GenericForeignKeyModelWithOptionalData)
+
 
 class DummyNullFieldsModel(models.Model):
     null_foreign_key = models.ForeignKey(

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -374,6 +374,16 @@ class TestFillingGenericForeignKeyField:
         assert isinstance(dummy.content_type, ContentType)
         assert dummy.content_type.model_class() is not None
 
+    def test_with_fill_optional_but_content_object_none(self):
+        dummy = baker.make(
+            models.GenericForeignKeyModelWithOptionalData,
+            content_object=None,
+            _fill_optional=True,
+        )
+        assert dummy.content_object is None
+        assert dummy.content_type is None
+        assert dummy.object_id is None
+
 
 @pytest.mark.django_db
 class TestFillingForeignKeyFieldWithDefaultFunctionReturningId:


### PR DESCRIPTION
**Describe the change**
We don't want to set `content_type` and `object_id` fields to a random values in case where the `content_object` is None, but `_fill_optional=True`.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed
