### PR TITLE
Fix #479 -- Make sure `db_default` is being considered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
 ### Added
+- Support to Field `db_default` value
 
 ### Changed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -27,6 +27,7 @@ from django.db.models import (
     Model,
     OneToOneField,
 )
+from django.db.models.fields import NOT_PROVIDED
 from django.db.models.fields.proxy import OrderWrt
 from django.db.models.fields.related import (
     ReverseManyToOneDescriptor as ForeignRelatedObjectsDescriptor,
@@ -727,6 +728,7 @@ class Baker(Generic[M]):
 
         Generator Resolution Precedence Order:
         -- `field.default` - model field default value, unless explicitly overwritten during baking
+        -- `field.db_default` - model field db default value, unless explicitly overwritten
         -- `attr_mapping` - mapping per attribute name
         -- `choices` -- mapping from available field choices
         -- `type_mapping` - mapping from user defined type associated generators
@@ -750,6 +752,8 @@ class Baker(Generic[M]):
             if callable(field.default):
                 return field.default()
             return field.default
+        elif field.db_default != NOT_PROVIDED:
+            return field.db_default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]
         elif field.choices:

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -752,7 +752,7 @@ class Baker(Generic[M]):
             if callable(field.default):
                 return field.default()
             return field.default
-        elif field.db_default != NOT_PROVIDED:
+        elif getattr(field, "db_default", NOT_PROVIDED) != NOT_PROVIDED:
             return field.db_default
         elif field.name in self.attr_mapping:
             generator = self.attr_mapping[field.name]

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -103,6 +103,7 @@ class Person(models.Model):
     email = models.EmailField()
     id_document = models.CharField(unique=True, max_length=10)
     data = models.JSONField()
+    retirement_age = models.IntegerField(db_default=20)
 
     try:
         from django.contrib.postgres.fields import (

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -103,7 +103,8 @@ class Person(models.Model):
     email = models.EmailField()
     id_document = models.CharField(unique=True, max_length=10)
     data = models.JSONField()
-    retirement_age = models.IntegerField(db_default=20)
+    if django.VERSION >= (5, 0):
+        retirement_age = models.IntegerField(db_default=20)
 
     try:
         from django.contrib.postgres.fields import (

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -202,6 +202,11 @@ class TestFillingIntFields:
         assert isinstance(small_int_field, fields.SmallIntegerField)
         assert isinstance(dummy_int_model.small_int_field, int)
 
+    def test_respects_db_default(self):
+        person = baker.make(models.Person, age=10)
+        assert person.age == 10
+        assert person.retirement_age == 20
+
 
 @pytest.mark.django_db
 class TestFillingPositiveIntFields:

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from os.path import abspath
 from tempfile import gettempdir
 
+import django
 from django.conf import settings
 from django.core.validators import (
     validate_ipv4_address,
@@ -202,6 +203,10 @@ class TestFillingIntFields:
         assert isinstance(small_int_field, fields.SmallIntegerField)
         assert isinstance(dummy_int_model.small_int_field, int)
 
+    @pytest.mark.skipif(
+        django.VERSION < (5, 0),
+        reason="The db_default field attribute was added after 5.0",
+    )
     def test_respects_db_default(self):
         person = baker.make(models.Person, age=10)
         assert person.age == 10


### PR DESCRIPTION
Closes https://github.com/model-bakers/model_bakery/issues/479

**Describe the change**
This PR changes the `Baker.generate_value` method to also consider the values configured in `Field.db_default`.