### PR TITLE
Fix coverage artifact uploading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ matrix.python-version }}
+          include-hidden-files: true
           path: '.coverage.*'
           if-no-files-found: ignore
 


### PR DESCRIPTION
Addressing breaking changes in GitHub Action:
https://github.com/actions/upload-artifact/releases/tag/v4.4.0
