### PR TITLE
fix: auto now fields should be skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fix support of `auto_now` and `auto_now_add` fields in combination with `_fill_optional`
 
 ### Removed
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1124,3 +1124,17 @@ class TestAutoNowFields:
         assert instance.created == now
         assert instance.updated == now
         assert instance.sent_date == now
+
+    @pytest.mark.django_db
+    @pytest.mark.xfail
+    def test_make_with_auto_now_and_fill_optional(self):
+        instance = baker.make(
+            models.ModelWithAutoNowFields,
+            _fill_optional=True,
+        )
+        created, updated = instance.created, instance.updated
+
+        instance.refresh_from_db()
+
+        assert instance.created == created
+        assert instance.updated == updated

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1126,7 +1126,6 @@ class TestAutoNowFields:
         assert instance.sent_date == now
 
     @pytest.mark.django_db
-    @pytest.mark.xfail
     def test_make_with_auto_now_and_fill_optional(self):
         instance = baker.make(
             models.ModelWithAutoNowFields,


### PR DESCRIPTION
**Describe the change**


- Issue: When `baker.make` with `_fill_optional` set as True, the values of those `DateTimeField` with `auto_now_add=True` or `auto_now=True` from the resulting instance are different from the value stored in DB.
  - <details><summary>The test case from the first commit is to reproduce the issue</summary>
    <img width="1444" alt="image" src="https://github.com/user-attachments/assets/e3ec99ae-bd8c-45e3-97b6-c77daee3d8b8">
    </details> 
- solution: skip the auto datetime fields

**PR Checklist**

- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed
