### PR TITLE
Isolate Recipe defaults to prevent modification via instances

### DIFF
--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import itertools
 from typing import (
     Any,
@@ -79,6 +80,8 @@ class Recipe(Generic[M]):
                     mapping[k] = v.recipe.prepare(_using=_using, **recipe_attrs)
             elif isinstance(v, related):
                 mapping[k] = v.make
+            elif isinstance(v, collections.abc.Container):
+                mapping[k] = copy.deepcopy(v)
 
         mapping.update(new_attrs)
         mapping.update(rel_fields_attrs)


### PR DESCRIPTION
**Describe the problem**

If a recipe defines default values for list-based or dict-based fields (such as `JSONField` or `ArrayField`), the objects built from this recipe directly refer to these recipe defaults instead of holding their own copy of the data.

Therefore, any modifications on these fields affect the recipe "parent" attribute and all depending instances. In my opinion/experience, this behavior is unexpected and error prone.

**Note:** For other data types, the isolation between recipe and instances is already guaranteed, which is also an argument to apply the same behavior in all cases.

**Describe the proposed change**

With this change, every baked instance holds an isolated copy of the recipe default attributes of any Container class (e.g., `dict` or `list`). This prevents from affecting the parent recipe, and other (existing or future) instances, when such fields are modified on an instance.

**Note:** The intent of this PR is trying to be "as clear as possible", without claiming to have properly solved the problem itself. The _resolving_ implementation proposed is my "best bet", but it might be quite naive, and could likely miss important elements. Please feel free to pick what you like and create a new PR that would supersede it (especially if you feel you can fix it quickly without much coordination/communication overhead here 😉). 

**Workaround**

With the current situation, it is possible to use a Callable as workaround to provide an immutable default value for list-based or dict-based attributes:

```python
def get_data():
   return {"one": 1}

my_recipe = Recipe(MyModel, data=get_data, ...)
```

This solution is but not convenient as it requires awareness of the recipe behavior (and additional code).

**PR Checklist**
- [x] Change is covered with tests
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated if needed -> to be discussed in PR review
