### PR TITLE
Remove deprecation warning of datetime.datetime.utcfromtimestamp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
+- Remove deprecation warning of `datetime.datetime.utcfromtimestamp`.
 
 ## [1.20.0](https://pypi.org/project/model-bakery/1.20.0/)
 

--- a/model_bakery/timezone.py
+++ b/model_bakery/timezone.py
@@ -8,6 +8,6 @@ from django.conf import settings
 def tz_aware(value: datetime) -> datetime:
     """Return an UTC-aware datetime in case of USE_TZ=True."""
     if settings.USE_TZ:
-        value = value.replace(tzinfo=timezone.utc)
+        return value.replace(tzinfo=timezone.utc)
 
-    return value
+    return value.replace(tzinfo=None)

--- a/model_bakery/utils.py
+++ b/model_bakery/utils.py
@@ -86,7 +86,10 @@ def seq(value, increment_by=1, start=None, suffix=None):
         start = (date - epoch_datetime).total_seconds()
         increment_by = increment_by.total_seconds()
         for n in itertools.count(increment_by, increment_by):
-            series_date = tz_aware(datetime.datetime.utcfromtimestamp(start + n))
+            series_date = tz_aware(
+                datetime.datetime.fromtimestamp(start + n, tz=datetime.timezone.utc)
+            )
+
             if type(value) is datetime.time:
                 yield series_date.time()
             elif type(value) is datetime.date:


### PR DESCRIPTION
**Describe the change**
Remove deprecation warning of datetime.datetime.utcfromtimestamp.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed
