### PR TITLE
fix: Recipe prepare

### DIFF
--- a/model_bakery/recipe.py
+++ b/model_bakery/recipe.py
@@ -164,9 +164,11 @@ class Recipe(Generic[M]):
         **attrs: Any,
     ) -> Union[M, List[M]]:
         defaults = {
-            "_quantity": _quantity,
             "_save_related": _save_related,
         }
+        if _quantity is not None:
+            defaults["_quantity"] = _quantity  # type: ignore[assignment]
+
         defaults.update(attrs)
         return baker.prepare(
             self._model, _using=_using, **self._mapping(_using, defaults)

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -20,7 +20,9 @@ from model_bakery.exceptions import (
 )
 from model_bakery.timezone import tz_aware
 from tests.generic import models
+from tests.generic.baker_recipes import lonely_person
 from tests.generic.forms import DummyGenericIPAddressFieldForm
+from tests.generic import baker_recipes
 
 
 def test_import_seq_from_baker():
@@ -282,6 +284,12 @@ class TestBakerPrepareSavingRelatedInstances:
 
     def test_create_one_to_one(self):
         lonely_person = baker.prepare(models.LonelyPerson, _save_related=True)
+
+        assert lonely_person.pk is None
+        assert lonely_person.only_friend.pk
+
+    def test_recipe_prepare_model_with_one_to_one_and_save_related(self):
+        lonely_person = baker_recipes.lonely_person.prepare(_save_related=True)
 
         assert lonely_person.pk is None
         assert lonely_person.only_friend.pk


### PR DESCRIPTION
**Describe the change**
Fixed the error that when using `Recipe.prepare` the _quantity parameter was None

Error stack trace

```shell
tests/test_baker.py:292: in test_recipe_prepare_model_with_one_to_one_and_save_related
    lonely_person = baker_recipes.lonely_person.prepare(_save_related=True)
model_bakery/recipe.py:175: in prepare
    self._model, _using=_using, **self._mapping(_using, defaults)
model_bakery/recipe.py:72: in _mapping
    for _ in range(_quantity)
E   TypeError: 'NoneType' object cannot be interpreted as an integer
```

**PR Checklist**
- [x] Change is covered with tests
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated if needed
