### PR TITLE
fix: run `ruff check .` when `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ release:
 
 lint:
 	@black .
-	@ruff .
+	@ruff check .
 	@mypy model_bakery
 
 .PHONY: help test release lint


### PR DESCRIPTION
**Describe the change**

Run `make lint` would fail now since `ruff <path>` is obsoleted by `ruff check <path>`.

<img width="438" height="127" alt="image" src="https://github.com/user-attachments/assets/bf942380-214e-4a25-aa5c-34580eb79ee1" />


**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed -> not needed
