### PR TITLE
Drop fallbacks made for Django < 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Removed
+- Drop fallbacks made for Django < 4.2
 
 ## [1.20.5](https://pypi.org/project/model-bakery/1.20.5/)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,7 @@ def pytest_configure():
         extra_db_name = ":memory:"
     elif test_db == "postgresql":
         using_postgres_flag = True
-        if django.VERSION >= (4, 2):
-            db_engine = "django.db.backends.postgresql"
-        else:
-            db_engine = "django.db.backends.postgresql_psycopg2"
+        db_engine = "django.db.backends.postgresql"
         db_name = "postgres"
         installed_apps = ["django.contrib.postgres"] + installed_apps
         extra_db_name = "extra_db"

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -125,8 +125,9 @@ class Person(models.Model):
         )
 
         if settings.USING_POSTGRES:
-            if django.VERSION >= (4, 2):
-                long_name = models.CharField()
+            long_name = (
+                models.CharField()
+            )  # max_length is not required as PostgresSQL supports unlimited VARCHAR
             acquaintances = ArrayField(models.IntegerField())
             hstore_data = HStoreField()
             ci_char = CICharField(max_length=30)


### PR DESCRIPTION
A couple of leftover checks we could drop since [Django 4.2 is the minimally supported version](https://endoflife.date/django).