### PR TITLE
Improve numeric generators and drop internal `gen_integer` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [dev] Various improvements to CI Python/Django matrices
 - The creation of generic foreign key fields now respects their `for_concrete_model` configuration
+- Refactor `gen_float()` to use `uniform()` with configurable `min_float`/`max_float` bounds instead of `random() * gen_integer()` which produced skewed distribution
+- Refactor `gen_interval()` to use `min_interval`/`max_interval` instead of `offset` parameter which never worked as intended due to huge `MAX_INT` range
+- Fix `gen_date_range()` and `gen_datetime_range()` to prevent empty ranges by enforcing a minimum interval of 1 day
+- Use `baker_random.randint()` directly in `gen_pg_numbers_range()` instead of `gen_integer()`
 
 ### Removed
 - Drop fallbacks made for Django < 4.2

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -80,8 +80,13 @@ def gen_integer(min_int: int = -MAX_INT, max_int: int = MAX_INT) -> int:
     return baker_random.randint(min_int, max_int)
 
 
-def gen_float() -> float:
-    return baker_random.random() * gen_integer()
+def gen_float(min_float: float = -1000000.0, max_float: float = 1000000.0) -> float:
+    """
+    Generate a random float uniformly distributed between `min_float` and `max_float`.
+
+    Defaults to ±1,000,000.0 which is suitable for most test data scenarios.
+    """
+    return baker_random.uniform(min_float, max_float)
 
 
 def gen_decimal(max_digits: int, decimal_places: int) -> Decimal:
@@ -212,9 +217,18 @@ def gen_byte_string(max_length: int = 16) -> bytes:
     return bytes(generator)
 
 
-def gen_interval(interval_key: str = "milliseconds", offset: int = 0) -> timedelta:
-    interval = gen_integer() + offset
-    kwargs = {interval_key: interval}
+def gen_interval(
+    interval_key: str = "milliseconds",
+    min_interval: int = -365 * 24 * 60 * 60 * 1000,
+    max_interval: int = 365 * 24 * 60 * 60 * 1000,
+) -> timedelta:
+    """
+    Generate a random timedelta for `DurationField` or date range calculations.
+
+    Defaults to ±1 year in milliseconds, suitable for most test scenarios.
+    The `interval_key` determines which timedelta argument is set (e.g., 'seconds', 'days').
+    """
+    kwargs = {interval_key: baker_random.randint(min_interval, max_interval)}
     return timedelta(**kwargs)
 
 
@@ -342,37 +356,56 @@ def gen_geometry_collection() -> str:
 
 
 def gen_pg_numbers_range(number_cast: Callable[[int], Any]) -> Callable:
+    """
+    Factory that returns a generator for PostgreSQL numeric range fields.
+
+    The returned generator creates ranges like [-N, N] where N is a random value
+    between 1 and 100,000, cast to the appropriate numeric type (int, float, etc).
+    """
+
     def gen_range():
         try:
             from psycopg.types.range import Range
         except ImportError:
             from psycopg2._range import NumericRange as Range
 
-        base_num = gen_integer(1, 100000)
+        base_num = baker_random.randint(1, 100000)
         return Range(number_cast(-1 * base_num), number_cast(base_num))
 
     return gen_range
 
 
 def gen_date_range():
+    """
+    Generate random `DateRange` for PostgreSQL `DateRangeField`.
+
+    The range spans a random date with a minimum interval of 1 day
+    to avoid empty ranges in tests.
+    """
     try:
         from psycopg.types.range import DateRange
     except ImportError:
         from psycopg2.extras import DateRange
 
     base_date = gen_date()
-    interval = gen_interval(offset=24 * 60 * 60 * 1000)  # force at least 1 day interval
+    interval = gen_interval(min_interval=24 * 60 * 60 * 1000)
     args = sorted([base_date - interval, base_date + interval])
     return DateRange(*args)
 
 
 def gen_datetime_range():
+    """
+    Generate random `TimestamptzRange` for PostgreSQL DateTimeRangeField.
+
+    The range spans a random datetime with a minimum interval of 1 day
+    to avoid empty ranges in tests.
+    """
     try:
         from psycopg.types.range import TimestamptzRange
     except ImportError:
         from psycopg2.extras import DateTimeTZRange as TimestamptzRange
 
     base_datetime = gen_datetime()
-    interval = gen_interval()
+    interval = gen_interval(min_interval=24 * 60 * 60 * 1000)
     args = sorted([base_datetime - interval, base_datetime + interval])
     return TimestamptzRange(*args)


### PR DESCRIPTION
**Describe the change**

While working on #528 to introduce new field-specific integer generators, I decided to refactor existing numeric generators as a first step (since they were using `gen_integer` under the hood):

- `gen_float`: use `uniform()` with configurable min/max bounds instead of `random() * gen_integer()` which produced skewed distribution
- `gen_interval`: replace broken `offset` param with `min_interval`/`max_interval`; offset never worked as intended due to huge `MAX_INT` range
- `gen_datetime_range`: add `min_interval` to prevent empty ranges
- `gen_pg_numbers_range`: use `randint()` directly


>Note

Why `offset` argument removal isn't a breaking concern (in my opinion, but happy to hear the opposite):
The `offset` parameter on `gen_interval()` was only [added to be used internally](https://github.com/model-bakers/model_bakery/pull/86/changes#diff-eba92df8cb0543a9d6a27bb3878dec6b79c0eb9f879b20a4f39f452b69a0a02eR194) in `gen_date_range()` with a specific value. Given that the parameter was fundamentally broken (the huge `MAX_INT` range made it impossible to guarantee a minimum offset), removing it and replacing with proper `min_interval`/`max_interval` parameters actually fixes the underlying bug.

*however, it is kinda flaky to say what is part of a public API and what is not in our case - maybe we could do a better job there.


**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed
