### PR TITLE
Drop EOL Django 5.0 and 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["4.2", "5.0", "5.1", "5.2", "6.0"]
+        django-version: ["4.2", "5.2", "6.0"]
         exclude:
           # Django 6.0 supports Python 3.12+
           - python-version: "3.10"
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["4.2", "5.0", "5.1", "5.2", "6.0"]
+        django-version: ["4.2", "5.2", "6.0"]
         variant: ["postgresql", "postgresql-psycopg3"]
         exclude:
           # Django 6.0 supports Python 3.12+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Fix `related()` with FK relations creating duplicate parent entities ([#397](https://github.com/model-bakers/model_bakery/issues/397))
+- [dev] CI: use uv for faster dependency installation and caching
 
 ### Removed
+- Drop EOL Django 5.0 and 5.1 support
 
 ## [1.22.1](https://pypi.org/project/model-bakery/1.22.1/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
-    # Python 3.10+ - Django 4.2-5.2
-    py{310,311,312,313,314}-django{42,50,51,52}-{sqlite,postgresql,postgresql-psycopg3}
+    # Python 3.10+ - Django 4.2, 5.2
+    py{310,311,312,313,314}-django{42,52}-{sqlite,postgresql,postgresql-psycopg3}
     # Python 3.12+ - Django 6.0
     py{312,313,314}-django60-{sqlite,postgresql,postgresql-psycopg3}
     # Latest Python/Django without contenttypes
@@ -25,8 +25,6 @@ deps =
     pytest
     pytest-django
     django42: Django>=4.2,<5
-    django50: Django>=5.0,<5.1
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
     django60: Django>=6.0a1,<6.1
     postgresql: psycopg2-binary


### PR DESCRIPTION
**Describe the change**
- Drop EOL Django 5.0 and 5.1 support

**PR Checklist**
- [ ] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Dropped end-of-life Django 5.0 and 5.1 support. Project now officially supports Django 4.2, 5.2, and 6.0 only.

* **Chores**
  * Updated continuous integration and testing infrastructure to reflect supported Django versions by removing 5.0 and 5.1 from test matrix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->