### PR TITLE
Fix flaky CT tests

### DIFF
--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -320,6 +320,19 @@ class TestFillingIPAddressField:
     not BAKER_CONTENTTYPES, reason="Django contenttypes framework is not installed"
 )
 class TestFillingGenericForeignKeyField:
+    @pytest.fixture(autouse=True)
+    def clear_content_type_cache(self):
+        """Clear ContentType cache to avoid stale entries from rolled-back transactions.
+
+        pytest-django doesn't clear the ContentType cache between tests (unlike Site cache).
+        This can cause FK violations on PostgreSQL when a cached ContentType references
+        a pk that was created in a rolled-back transaction.
+        See: https://github.com/pytest-dev/pytest-django/issues/1156
+        """
+        from django.contrib.contenttypes.models import ContentType
+
+        ContentType.objects.clear_cache()
+
     @pytest.mark.django_db
     def test_content_type_field(self):
         from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
**Describe the change**
Finally figured (hopefully) out where flaky `ContentType` tests are coming from.
https://github.com/pytest-dev/pytest-django/issues/1156

Adding a fixture to clear the cache between the tests.

**PR Checklist**
- [ ] Change is covered with tests
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by fixing cache-related issues that could cause intermittent test failures, particularly on PostgreSQL systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->