### PR TITLE
Fix `_bulk_create` for `ManyToManyField` with custom through models (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fix `_bulk_create` for ManyToManyField using custom `through` models ([#477](https://github.com/model-bakers/model_bakery/issues/477))
 - [dev] Clean up stale TODO and fix signal handler leak in m2m test
 
 ### Removed

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -940,8 +940,8 @@ def bulk_create(baker: Baker[M], quantity: int, **kwargs) -> list[M]:
                     [
                         through_model(
                             **{
-                                field.remote_field.name: entry,
-                                field.related_model._meta.model_name: obj,
+                                field.m2m_field_name(): entry,
+                                field.m2m_reverse_field_name(): obj,
                             }
                         )
                         for obj in kwargs[field.name]

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -459,6 +459,31 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert models.Person.objects.count() == 6
 
     @pytest.mark.django_db
+    def test_bulk_create_with_m2m(self):
+        """Regression test for issue #477."""
+        employees = baker.make(models.Person, _quantity=3)
+        stores = baker.make(
+            models.Store, employees=employees, _quantity=2, _bulk_create=True
+        )
+
+        assert models.Store.objects.count() == 2
+        assert stores[0].employees.count() == 3
+        assert stores[1].employees.count() == 3
+
+    @pytest.mark.django_db
+    def test_bulk_create_with_m2m_through_model(self):
+        """Regression test for issue #477 - custom through model."""
+        students = baker.make(models.Person, _quantity=3)
+        schools = baker.make(
+            models.School, students=students, _quantity=2, _bulk_create=True
+        )
+
+        assert models.School.objects.count() == 2
+        assert schools[0].students.count() == 3
+        assert schools[1].students.count() == 3
+        assert models.SchoolEnrollment.objects.count() == 6
+
+    @pytest.mark.django_db
     def test_create_many_to_many_with_iter(self):
         students = baker.make(models.Person, _quantity=3)
         classrooms = baker.make(models.Classroom, _quantity=3, students=iter(students))


### PR DESCRIPTION
**Describe the change**
I figured that `bulk_create` was using incorrect properties (the related model's name/related_name) for getting FK names.

Replaced `field.remote_field.name` and `field.related_model._meta.model_name` with Django's `field.m2m_field_name()` and `field.m2m_reverse_field_name()` ([ref](https://github.com/django/django/blob/3851601b2e080df34fb9227fe5d2fd43af604263/django/db/models/fields/related_descriptors.py#L1059-L1078)) which return the correct FK field names for both auto-created and custom through models.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk creation of objects with many-to-many relationships when using custom through models.

* **Tests**
  * Added regression tests for bulk creation with many-to-many relationships and through models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->