### PR TITLE
Fix #462 -- Allow `_bulk_create=True` without `_quantity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Allow `_bulk_create=True` without `_quantity` ([#462](https://github.com/model-bakers/model_bakery/issues/462))
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -135,8 +135,9 @@ def make(
     if _valid_quantity(_quantity):
         raise InvalidQuantityException
 
-    if _quantity and _bulk_create:
-        return bulk_create(baker, _quantity, _save_kwargs=_save_kwargs, **attrs)
+    if _bulk_create:
+        result = bulk_create(baker, _quantity or 1, _save_kwargs=_save_kwargs, **attrs)
+        return result if _quantity else result[0]
     elif _quantity:
         return [
             baker.make(

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -183,6 +183,19 @@ class TestsBakerRepeatedCreatesSimpleModel(TestCase):
         assert models.NonStandardManager.manager.count() == 3
 
     @pytest.mark.django_db
+    def test_make_bulk_create_without_quantity(self):
+        """Issue #462: _bulk_create=True without _quantity should use bulk_create."""
+        with patch.object(
+            models.Person._base_manager,
+            "bulk_create",
+            wraps=models.Person._base_manager.bulk_create,
+        ) as mock_bulk:
+            person = baker.make(models.Person, _bulk_create=True)
+        mock_bulk.assert_called_once()
+        assert isinstance(person, models.Person)
+        assert person.pk is not None
+
+    @pytest.mark.django_db
     def test_make_raises_correct_exception_if_invalid_quantity(self):
         with pytest.raises(InvalidQuantityException):
             baker.make(_model=models.Person, _quantity="hi")


### PR DESCRIPTION
**Describe the change**
Allows `baker.make(Model, _bulk_create=True)` to work without specifying `_quantity`. In this case it returns a single object (not a list), which is consistent with the usual `make()` behavior.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The _bulk_create parameter can now be used independently without requiring _quantity specification, returning a single created instance when _quantity is not provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->