### PR TITLE
Fix reverse OneToOneField relations not being persisted to the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - When using `baker.make(..., _bulk_create=True, _full_clean=True)`, the operation is wrapped in a transaction to ensure atomic rollback if validation fails
 - Use the requested `_using` database consistently for generated related objects in `baker.make(..., _bulk_create=True)`
 - Preserve correct parent-to-FK associations in `baker.make(..., _bulk_create=True)` when related objects mix saved and unsaved instances
+- Fix reverse `OneToOneField` relations not being persisted to the database when passed as kwargs to `baker.make()` ([#473](https://github.com/model-bakers/model_bakery/issues/473))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix reverse `OneToOneField` relations not being persisted to the database when passed as kwargs to `baker.make()`, including iterators and bulk creation ([#473](https://github.com/model-bakers/model_bakery/issues/473))
 - Fix explicit `auto_now`/`auto_now_add` values being written to the wrong database when `_using` is set, and route the follow-up `UPDATE` through `_base_manager` so it also works on models without an `objects` manager or with a filtered default manager
 - [dev] Extract the attr-partitioning logic out of `Baker.instance()` into a pure, database-free `Baker._classify_attrs()` helper, with direct unit tests asserting it runs zero queries
 - [dev] Add Django 6.1 support and CI coverage
@@ -27,7 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - When using `baker.make(..., _bulk_create=True, _full_clean=True)`, the operation is wrapped in a transaction to ensure atomic rollback if validation fails
 - Use the requested `_using` database consistently for generated related objects in `baker.make(..., _bulk_create=True)`
 - Preserve correct parent-to-FK associations in `baker.make(..., _bulk_create=True)` when related objects mix saved and unsaved instances
-- Fix reverse `OneToOneField` relations not being persisted to the database when passed as kwargs to `baker.make()` ([#473](https://github.com/model-bakers/model_bakery/issues/473))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - When using `baker.make(..., _bulk_create=True, _full_clean=True)`, the operation is wrapped in a transaction to ensure atomic rollback if validation fails
 - Use the requested `_using` database consistently for generated related objects in `baker.make(..., _bulk_create=True)`
 - Preserve correct parent-to-FK associations in `baker.make(..., _bulk_create=True)` when related objects mix saved and unsaved instances
+- Fix reverse `OneToOneField` relations not being persisted to the database when passed as kwargs to `baker.make()` ([#473](https://github.com/model-bakers/model_bakery/issues/473))
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -28,6 +28,7 @@ from django.db.models.fields.proxy import OrderWrt
 from django.db.models.fields.related import (
     ReverseManyToOneDescriptor as ForeignRelatedObjectsDescriptor,
 )
+from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor
 from django.db.models.fields.reverse_related import (
     ForeignObjectRel,
     ManyToOneRel,
@@ -562,20 +563,24 @@ class Baker(Generic[M]):
 
     def _classify_attrs(
         self, attrs: dict[str, Any]
-    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-        """Partition ``attrs`` into reverse-FK, auto-now, and GFK groups.
+    ) -> tuple[
+        dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]
+    ]:
+        """Partition ``attrs`` into reverse-FK, reverse-one-to-one, auto-now, and GFK groups.
 
         Pure logic, no database access: normalizes the model's field descriptors
         to their backing fields and routes entries that cannot be passed straight
-        to the model constructor. Reverse one-to-many and generic-foreign-key
-        entries are *popped* out of ``attrs`` (they are applied after the instance
-        exists); auto-now entries are *copied* out (the value is also kept on
-        ``attrs`` and re-applied via an UPDATE after save, since Django overwrites
-        ``auto_now``/``auto_now_add`` fields on save).
+        to the model constructor. Reverse one-to-many, reverse-one-to-one, and
+        generic-foreign-key entries are *popped* out of ``attrs`` (they are applied
+        after the instance exists); auto-now entries are *copied* out (the value is
+        also kept on ``attrs`` and re-applied via an UPDATE after save, since Django
+        overwrites ``auto_now``/``auto_now_add`` fields on save).
 
-        Returns ``(one_to_many_keys, auto_now_keys, generic_foreign_keys)``.
+        Returns ``(one_to_many_keys, reverse_one_to_one_keys, auto_now_keys,
+        generic_foreign_keys)``.
         """
         one_to_many_keys = {}
+        reverse_one_to_one_keys = {}
         auto_now_keys = {}
         generic_foreign_keys = {}
 
@@ -587,6 +592,8 @@ class Baker(Generic[M]):
 
             if isinstance(descriptor, ForeignRelatedObjectsDescriptor):
                 one_to_many_keys[name] = attrs.pop(name)
+            elif isinstance(descriptor, ReverseOneToOneDescriptor):
+                reverse_one_to_one_keys[name] = attrs.pop(name)
 
             field = getattr(descriptor, "field", descriptor)
             if _is_auto_datetime_field(field):
@@ -600,7 +607,7 @@ class Baker(Generic[M]):
                     "for_concrete_model": field.for_concrete_model,
                 }
 
-        return one_to_many_keys, auto_now_keys, generic_foreign_keys
+        return one_to_many_keys, reverse_one_to_one_keys, auto_now_keys, generic_foreign_keys
 
     def instance(
         self,
@@ -610,9 +617,12 @@ class Baker(Generic[M]):
         _from_manager,
         _full_clean=False,
     ) -> M:
-        one_to_many_keys, auto_now_keys, generic_foreign_keys = self._classify_attrs(
-            attrs
-        )
+        (
+            one_to_many_keys,
+            reverse_one_to_one_keys,
+            auto_now_keys,
+            generic_foreign_keys,
+        ) = self._classify_attrs(attrs)
 
         instance = self.model(**attrs)
         if using := _save_kwargs.get("using"):
@@ -628,6 +638,7 @@ class Baker(Generic[M]):
         if _commit:
             instance.save(**_save_kwargs)
             self._handle_one_to_many(instance, one_to_many_keys)
+            self._handle_reverse_one_to_one(instance, reverse_one_to_one_keys)
             self._handle_m2m(instance)
             self._handle_auto_now(instance, auto_now_keys)
 
@@ -794,6 +805,26 @@ class Baker(Generic[M]):
             except TypeError:
                 # for many-to-many relationships the bulk keyword argument doesn't exist
                 manager.set(values, clear=True)
+
+    def _handle_reverse_one_to_one(
+        self, instance: Model, attrs: dict[str, Any]
+    ) -> None:
+        """Handle reverse one-to-one relationships.
+
+        Sets the FK on the related object to point to instance and saves it.
+        This mirrors what Django would do if the relation were set via the
+        forward FK, but on the reverse side.
+        """
+        for key, value in attrs.items():
+            if callable(value):
+                value = value()
+            if value is None:
+                continue
+            descriptor = getattr(self.model, key)
+            fk_field_name = descriptor.related.field.name
+            setattr(value, fk_field_name, instance)
+            save_kwargs = {"using": self._using} if self._using else {}
+            value.save(**save_kwargs)
 
     def _handle_m2m(self, instance: Model):
         for key, values in self.m2m_dict.items():

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -809,11 +809,10 @@ class Baker(Generic[M]):
     def _handle_reverse_one_to_one(
         self, instance: Model, attrs: dict[str, Any]
     ) -> None:
-        """Handle reverse one-to-one relationships.
+        """Persist related objects defined through a reverse OneToOne relation.
 
-        Sets the FK on the related object to point to instance and saves it.
-        This mirrors what Django would do if the relation were set via the
-        forward FK, but on the reverse side.
+        Sets the FK on the related object to point to ``instance`` and saves it,
+        consistent with how ``_handle_one_to_many`` persists reverse relations.
         """
         for key, value in attrs.items():
             if callable(value):

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -563,9 +563,7 @@ class Baker(Generic[M]):
 
     def _classify_attrs(
         self, attrs: dict[str, Any]
-    ) -> tuple[
-        dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]
-    ]:
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
         """Partition ``attrs`` into reverse-FK, reverse-one-to-one, auto-now, and GFK groups.
 
         Pure logic, no database access: normalizes the model's field descriptors
@@ -607,7 +605,12 @@ class Baker(Generic[M]):
                     "for_concrete_model": field.for_concrete_model,
                 }
 
-        return one_to_many_keys, reverse_one_to_one_keys, auto_now_keys, generic_foreign_keys
+        return (
+            one_to_many_keys,
+            reverse_one_to_one_keys,
+            auto_now_keys,
+            generic_foreign_keys,
+        )
 
     def instance(
         self,

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -635,13 +635,21 @@ class Baker(Generic[M]):
             instance, generic_foreign_keys, commit=_commit
         )
 
+        # Connect reverse one-to-one relations in memory both for make()
+        # (where they are also saved below) and for prepare() (where the
+        # supplied related object must be wired to the unsaved instance).
+        resolved_reverse_one_to_one = self._resolve_reverse_one_to_one(
+            reverse_one_to_one_keys
+        )
+        self._connect_reverse_one_to_one(instance, resolved_reverse_one_to_one)
+
         if _full_clean:
             instance.full_clean()
 
         if _commit:
             instance.save(**_save_kwargs)
             self._handle_one_to_many(instance, one_to_many_keys)
-            self._handle_reverse_one_to_one(instance, reverse_one_to_one_keys)
+            self._save_reverse_one_to_one(resolved_reverse_one_to_one)
             self._handle_m2m(instance)
             self._handle_auto_now(instance, auto_now_keys)
 
@@ -815,22 +823,38 @@ class Baker(Generic[M]):
                 # for many-to-many relationships the bulk keyword argument doesn't exist
                 manager.set(values, clear=True)
 
-    def _handle_reverse_one_to_one(
-        self, instance: Model, attrs: dict[str, Any]
-    ) -> None:
-        """Persist related objects defined through a reverse OneToOne relation.
-
-        Sets the FK on the related object to point to ``instance`` and saves it,
-        consistent with how ``_handle_one_to_many`` persists reverse relations.
-        """
+    def _resolve_reverse_one_to_one(self, attrs: dict[str, Any]) -> dict[str, Model]:
+        """Resolve callables and drop ``None`` values from reverse OneToOne attrs."""
+        resolved: dict[str, Model] = {}
         for key, value in attrs.items():
             if callable(value):
                 value = value()
-            if value is None:
-                continue
+            if value is not None:
+                resolved[key] = value
+        return resolved
+
+    def _connect_reverse_one_to_one(
+        self, instance: Model, attrs: dict[str, Model]
+    ) -> None:
+        """Wire reverse OneToOne related objects to ``instance`` in memory.
+
+        Sets the FK on the related object to point to ``instance`` and caches
+        the related object on ``instance`` so the relationship is usable both
+        for ``prepare()`` (no DB save) and before the related object is saved
+        during ``make()``.
+        """
+        for key, value in attrs.items():
             descriptor = getattr(self.model, key)
             fk_field_name = descriptor.related.field.name
             setattr(value, fk_field_name, instance)
+            instance.__dict__[key] = value
+
+    def _save_reverse_one_to_one(self, attrs: dict[str, Model]) -> None:
+        """Persist related objects defined through a reverse OneToOne relation.
+
+        Must be called after ``instance`` has been saved so the FK is valid.
+        """
+        for value in attrs.values():
             save_kwargs = {"using": self._using} if self._using else {}
             value.save(**save_kwargs)
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -815,11 +815,10 @@ class Baker(Generic[M]):
     def _handle_reverse_one_to_one(
         self, instance: Model, attrs: dict[str, Any]
     ) -> None:
-        """Handle reverse one-to-one relationships.
+        """Persist related objects defined through a reverse OneToOne relation.
 
-        Sets the FK on the related object to point to instance and saves it.
-        This mirrors what Django would do if the relation were set via the
-        forward FK, but on the reverse side.
+        Sets the FK on the related object to point to ``instance`` and saves it,
+        consistent with how ``_handle_one_to_many`` persists reverse relations.
         """
         for key, value in attrs.items():
             if callable(value):

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -1,5 +1,6 @@
 import collections
 from collections.abc import Callable, Iterable, Iterator
+from contextlib import nullcontext
 from inspect import Parameter, signature
 from os.path import dirname, join
 from typing import (
@@ -641,15 +642,25 @@ class Baker(Generic[M]):
         resolved_reverse_one_to_one = self._resolve_reverse_one_to_one(
             reverse_one_to_one_keys
         )
-        self._connect_reverse_one_to_one(instance, resolved_reverse_one_to_one)
+        for key, value in resolved_reverse_one_to_one.items():
+            setattr(instance, key, value)
 
         if _full_clean:
             instance.full_clean()
 
         if _commit:
-            instance.save(**_save_kwargs)
-            self._handle_one_to_many(instance, one_to_many_keys)
-            self._save_reverse_one_to_one(resolved_reverse_one_to_one)
+            with (
+                transaction.atomic(
+                    using=_save_kwargs.get("using") or instance._state.db
+                )
+                if _full_clean and resolved_reverse_one_to_one
+                else nullcontext()
+            ):
+                instance.save(**_save_kwargs)
+                self._handle_one_to_many(instance, one_to_many_keys)
+                self._save_reverse_one_to_one(
+                    instance, resolved_reverse_one_to_one, _full_clean=_full_clean
+                )
             self._handle_m2m(instance)
             self._handle_auto_now(instance, auto_now_keys)
 
@@ -824,39 +835,37 @@ class Baker(Generic[M]):
                 manager.set(values, clear=True)
 
     def _resolve_reverse_one_to_one(self, attrs: dict[str, Any]) -> dict[str, Model]:
-        """Resolve callables and drop ``None`` values from reverse OneToOne attrs."""
+        """Resolve callables and iterators, omitting absent reverse relations."""
         resolved: dict[str, Model] = {}
         for key, value in attrs.items():
             if callable(value):
                 value = value()
+            if is_iterator(value):
+                try:
+                    value = next(value)
+                except StopIteration:
+                    raise RecipeIteratorEmpty(f"{key} iterator is empty.")
             if value is not None:
                 resolved[key] = value
         return resolved
 
-    def _connect_reverse_one_to_one(
-        self, instance: Model, attrs: dict[str, Model]
+    def _save_reverse_one_to_one(
+        self, instance: Model, keys: Iterable[str], _full_clean: bool = False
     ) -> None:
-        """Wire reverse OneToOne related objects to ``instance`` in memory.
-
-        Sets the FK on the related object to point to ``instance`` and caches
-        the related object on ``instance`` so the relationship is usable both
-        for ``prepare()`` (no DB save) and before the related object is saved
-        during ``make()``.
-        """
-        for key, value in attrs.items():
+        save_kwargs = {"using": self._using} if self._using else {}
+        # Read the values resolved during prepare(), without consuming inputs again.
+        for key in keys:
             descriptor = getattr(self.model, key)
-            fk_field_name = descriptor.related.field.name
-            setattr(value, fk_field_name, instance)
-            instance.__dict__[key] = value
-
-    def _save_reverse_one_to_one(self, attrs: dict[str, Model]) -> None:
-        """Persist related objects defined through a reverse OneToOne relation.
-
-        Must be called after ``instance`` has been saved so the FK is valid.
-        """
-        for value in attrs.values():
-            save_kwargs = {"using": self._using} if self._using else {}
-            value.save(**save_kwargs)
+            value = descriptor.related.get_cached_value(instance, default=None)
+            if value is not None:
+                # The parent's PK may only have become available after bulk_create().
+                setattr(instance, key, value)
+                _save_related_objs(
+                    type(value), [value], _using=self._using, _full_clean=_full_clean
+                )
+                if _full_clean and value._state.adding:
+                    value.full_clean()
+                value.save(**save_kwargs)
 
     def _handle_m2m(self, instance: Model):
         for key, values in self.m2m_dict.items():
@@ -1106,23 +1115,28 @@ def bulk_create(  # noqa: C901
     else:
         manager = baker.model._base_manager
 
-    if _full_clean:
-        with transaction.atomic(using=baker._using or None):
-            _save_related_objs(
-                baker.model,
-                entries,
-                _using=baker._using,
-                _full_clean=True,
-            )
+    reverse_one_to_one_keys = [
+        key
+        for key in kwargs
+        if isinstance(getattr(baker.model, key, None), ReverseOneToOneDescriptor)
+    ]
+    with (
+        transaction.atomic(using=baker._using or None) if _full_clean else nullcontext()
+    ):
+        _save_related_objs(
+            baker.model, entries, _using=baker._using, _full_clean=_full_clean
+        )
+        if _full_clean:
             for entry in entries:
                 entry.full_clean()
-            created_entries = manager.bulk_create(entries)
-    else:
-        _save_related_objs(baker.model, entries, _using=baker._using)
         created_entries = manager.bulk_create(entries)
+        for entry in created_entries:
+            baker._save_reverse_one_to_one(
+                entry, reverse_one_to_one_keys, _full_clean=_full_clean
+            )
 
-    # set many-to-many relations from kwargs
     for entry in created_entries:
+        # set many-to-many relations from kwargs
         for field in baker.model._meta.many_to_many:
             if field.name in kwargs:
                 through_model = getattr(entry, field.name).through

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -28,6 +28,7 @@ from django.db.models.fields.proxy import OrderWrt
 from django.db.models.fields.related import (
     ReverseManyToOneDescriptor as ForeignRelatedObjectsDescriptor,
 )
+from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor
 from django.db.models.fields.reverse_related import (
     ForeignObjectRel,
     ManyToOneRel,
@@ -562,20 +563,24 @@ class Baker(Generic[M]):
 
     def _classify_attrs(
         self, attrs: dict[str, Any]
-    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-        """Partition ``attrs`` into reverse-FK, auto-now, and GFK groups.
+    ) -> tuple[
+        dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]
+    ]:
+        """Partition ``attrs`` into reverse-FK, reverse-one-to-one, auto-now, and GFK groups.
 
         Pure logic, no database access: normalizes the model's field descriptors
         to their backing fields and routes entries that cannot be passed straight
-        to the model constructor. Reverse one-to-many and generic-foreign-key
-        entries are *popped* out of ``attrs`` (they are applied after the instance
-        exists); auto-now entries are *copied* out (the value is also kept on
-        ``attrs`` and re-applied via an UPDATE after save, since Django overwrites
-        ``auto_now``/``auto_now_add`` fields on save).
+        to the model constructor. Reverse one-to-many, reverse-one-to-one, and
+        generic-foreign-key entries are *popped* out of ``attrs`` (they are applied
+        after the instance exists); auto-now entries are *copied* out (the value is
+        also kept on ``attrs`` and re-applied via an UPDATE after save, since Django
+        overwrites ``auto_now``/``auto_now_add`` fields on save).
 
-        Returns ``(one_to_many_keys, auto_now_keys, generic_foreign_keys)``.
+        Returns ``(one_to_many_keys, reverse_one_to_one_keys, auto_now_keys,
+        generic_foreign_keys)``.
         """
         one_to_many_keys = {}
+        reverse_one_to_one_keys = {}
         auto_now_keys = {}
         generic_foreign_keys = {}
 
@@ -587,6 +592,8 @@ class Baker(Generic[M]):
 
             if isinstance(descriptor, ForeignRelatedObjectsDescriptor):
                 one_to_many_keys[name] = attrs.pop(name)
+            elif isinstance(descriptor, ReverseOneToOneDescriptor):
+                reverse_one_to_one_keys[name] = attrs.pop(name)
 
             field = getattr(descriptor, "field", descriptor)
             if _is_auto_datetime_field(field):
@@ -600,7 +607,7 @@ class Baker(Generic[M]):
                     "for_concrete_model": field.for_concrete_model,
                 }
 
-        return one_to_many_keys, auto_now_keys, generic_foreign_keys
+        return one_to_many_keys, reverse_one_to_one_keys, auto_now_keys, generic_foreign_keys
 
     def instance(
         self,
@@ -610,9 +617,12 @@ class Baker(Generic[M]):
         _from_manager,
         _full_clean=False,
     ) -> M:
-        one_to_many_keys, auto_now_keys, generic_foreign_keys = self._classify_attrs(
-            attrs
-        )
+        (
+            one_to_many_keys,
+            reverse_one_to_one_keys,
+            auto_now_keys,
+            generic_foreign_keys,
+        ) = self._classify_attrs(attrs)
 
         instance = self.model(**attrs)
         if using := _save_kwargs.get("using"):
@@ -628,6 +638,7 @@ class Baker(Generic[M]):
         if _commit:
             instance.save(**_save_kwargs)
             self._handle_one_to_many(instance, one_to_many_keys)
+            self._handle_reverse_one_to_one(instance, reverse_one_to_one_keys)
             self._handle_m2m(instance)
             self._handle_auto_now(instance, auto_now_keys)
 
@@ -800,6 +811,26 @@ class Baker(Generic[M]):
             except TypeError:
                 # for many-to-many relationships the bulk keyword argument doesn't exist
                 manager.set(values, clear=True)
+
+    def _handle_reverse_one_to_one(
+        self, instance: Model, attrs: dict[str, Any]
+    ) -> None:
+        """Handle reverse one-to-one relationships.
+
+        Sets the FK on the related object to point to instance and saves it.
+        This mirrors what Django would do if the relation were set via the
+        forward FK, but on the reverse side.
+        """
+        for key, value in attrs.items():
+            if callable(value):
+                value = value()
+            if value is None:
+                continue
+            descriptor = getattr(self.model, key)
+            fk_field_name = descriptor.related.field.name
+            setattr(value, fk_field_name, instance)
+            save_kwargs = {"using": self._using} if self._using else {}
+            value.save(**save_kwargs)
 
     def _handle_m2m(self, instance: Model):
         for key, values in self.m2m_dict.items():

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -84,6 +84,14 @@ class User(models.Model):
     username = models.CharField(max_length=32)
 
 
+class ProfileDetails(models.Model):
+    profile = models.OneToOneField(
+        Profile, related_name="details", on_delete=models.CASCADE
+    )
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    name = models.CharField(max_length=32)
+
+
 class PaymentBill(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     value = models.FloatField()

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -675,6 +675,24 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert person.fk_related.get().name == "Bar"
 
     @pytest.mark.django_db
+    def test_reverse_one_to_one_is_persisted(self):
+        """Regression test for issue #473.
+
+        Reverse OneToOne relations passed as kwargs must be saved to the DB,
+        not just exist in memory on the created instance.
+        """
+        # RelatedNamesModel.one_to_one = OneToOneField(Person, related_name="one_related")
+        # Person.one_related is the reverse accessor — this is the bug scenario.
+        placeholder = baker.make(models.Person)
+        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
+
+        person = baker.make(models.Person, one_related=related)
+
+        related.refresh_from_db()
+        assert related.one_to_one == person
+        assert models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
+
+    @pytest.mark.django_db
     def test_field_lookup_for_related_field_does_not_work_with_prepare(self):
         person = baker.prepare(
             models.Person,
@@ -1243,6 +1261,25 @@ class TestBakerSupportsMultiDatabase(TestCase):
         assert not models.School.objects.exists()
         assert not models.SchoolEnrollment.objects.exists()
         assert not models.Person.objects.exists()
+
+    def test_reverse_one_to_one_respects_using_kwarg(self):
+        """Reverse OneToOne handler must save related object to the correct DB."""
+        placeholder = baker.make(models.Person, _using=settings.EXTRA_DB)
+        related = baker.make(
+            models.RelatedNamesModel,
+            one_to_one=placeholder,
+            _using=settings.EXTRA_DB,
+        )
+        person = baker.make(
+            models.Person, one_related=related, _using=settings.EXTRA_DB
+        )
+        related.refresh_from_db(using=settings.EXTRA_DB)
+        assert related.one_to_one == person
+        assert (
+            models.RelatedNamesModel.objects.using(settings.EXTRA_DB)
+            .filter(one_to_one=person)
+            .exists()
+        )
 
 
 class TestBakerAutomaticallyRefreshFromDB:

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -681,8 +681,6 @@ class TestBakerCreatesAssociatedModels(TestCase):
         Reverse OneToOne relations passed as kwargs must be saved to the DB,
         not just exist in memory on the created instance.
         """
-        # RelatedNamesModel.one_to_one = OneToOneField(Person, related_name="one_related")
-        # Person.one_related is the reverse accessor — this is the bug scenario.
         placeholder = baker.make(models.Person)
         related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -283,14 +283,6 @@ class TestBakerPrepareSavingRelatedInstances:
         assert dog.owner is not None
         assert dog.owner.pk is None
 
-    def test_prepare_preserves_reverse_one_to_one(self):
-        related = models.RelatedNamesModel()
-
-        person = baker.prepare(models.Person, one_related=related)
-
-        assert person.one_related is related
-        assert related.one_to_one is person
-
     def test_access_reverse_fk_on_unsaved_instance(self):
         """Reverse FK and M2M access on unsaved instances raises ValueError."""
         dog = baker.prepare(models.Dog)
@@ -685,33 +677,6 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert person.fk_related.get().name == "Bar"
 
     @pytest.mark.django_db
-    def test_reverse_one_to_one_is_persisted(self):
-        """Regression test for issue #473.
-
-        Reverse OneToOne relations passed as kwargs must be saved to the DB,
-        not just exist in memory on the created instance.
-        """
-        placeholder = baker.make(models.Person)
-        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
-
-        person = baker.make(models.Person, one_related=related)
-
-        related.refresh_from_db()
-        assert related.one_to_one == person
-        assert models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
-
-    def test_prepare_reverse_one_to_one_is_connected_in_memory(self):
-        """Reverse OneToOne relations passed to prepare() must wire both sides in memory without persisting either object."""
-        placeholder = baker.make(models.Person)
-        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
-
-        person = baker.prepare(models.Person, one_related=related)
-
-        assert person.pk is None
-        assert person.one_related == related
-        assert related.one_to_one == person
-
-    @pytest.mark.django_db
     def test_field_lookup_for_related_field_does_not_work_with_prepare(self):
         person = baker.prepare(
             models.Person,
@@ -741,6 +706,63 @@ class TestBakerCreatesAssociatedModels(TestCase):
 
 
 class TestReverseOneToOne:
+    @pytest.mark.django_db
+    def test_reverse_one_to_one_is_persisted(self):
+        """Regression test for issue #473.
+
+        Reverse OneToOne relations passed as kwargs must be saved to the DB,
+        not just exist in memory on the created instance.
+        """
+        placeholder = baker.make(models.Person)
+        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
+
+        person = baker.make(models.Person, one_related=related)
+
+        related.refresh_from_db()
+        assert related.one_to_one == person
+        assert models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
+
+    def test_prepare_preserves_reverse_one_to_one(self):
+        related = models.RelatedNamesModel()
+
+        person = baker.prepare(models.Person, one_related=related)
+
+        assert person.one_related is related
+        assert related.one_to_one is person
+
+    @pytest.mark.django_db
+    def test_prepare_keeps_saved_relation_unchanged(self):
+        placeholder = baker.make(models.Person)
+        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
+
+        person = baker.prepare(models.Person, one_related=related)
+
+        assert person.pk is None
+        assert person.one_related is related
+        assert related.one_to_one is person
+        related.refresh_from_db()
+        assert related.one_to_one == placeholder
+
+    @pytest.mark.django_db(databases=["default", settings.EXTRA_DB])
+    def test_reverse_one_to_one_respects_using_kwarg(self):
+        """Reverse OneToOne handler must save related object to the correct DB."""
+        placeholder = baker.make(models.Person, _using=settings.EXTRA_DB)
+        related = baker.make(
+            models.RelatedNamesModel,
+            one_to_one=placeholder,
+            _using=settings.EXTRA_DB,
+        )
+        person = baker.make(
+            models.Person, one_related=related, _using=settings.EXTRA_DB
+        )
+        related.refresh_from_db(using=settings.EXTRA_DB)
+        assert related.one_to_one == person
+        assert (
+            models.RelatedNamesModel.objects.using(settings.EXTRA_DB)
+            .filter(one_to_one=person)
+            .exists()
+        )
+
     @pytest.mark.django_db
     @pytest.mark.parametrize("bulk_create", [False, True])
     def test_iterator_is_persisted(self, bulk_create):
@@ -773,10 +795,21 @@ class TestReverseOneToOne:
         assert related.one_to_one == person
 
     @pytest.mark.django_db
-    @pytest.mark.parametrize("saved", [False, True])
-    def test_bulk_create_persists_related_object(self, saved):
-        factory = baker.make if saved else baker.prepare
-        related = factory(models.RelatedNamesModel)
+    def test_bulk_create_relinks_existing_related_object(self):
+        related = baker.make(models.RelatedNamesModel)
+
+        person = baker.make(models.Person, one_related=related, _bulk_create=True)
+
+        related.refresh_from_db()
+        person.refresh_from_db()
+        assert related.one_to_one == person
+        assert person.one_related == related
+
+    @pytest.mark.django_db
+    def test_bulk_create_saves_prepared_object_with_unsaved_dependencies(self):
+        related = baker.prepare(models.RelatedNamesModel)
+        assert related.pk is None
+        assert related.foreign_key.pk is None
 
         person = baker.make(models.Person, one_related=related, _bulk_create=True)
 
@@ -1474,25 +1507,6 @@ class TestBakerSupportsMultiDatabase(TestCase):
         assert not models.School.objects.exists()
         assert not models.SchoolEnrollment.objects.exists()
         assert not models.Person.objects.exists()
-
-    def test_reverse_one_to_one_respects_using_kwarg(self):
-        """Reverse OneToOne handler must save related object to the correct DB."""
-        placeholder = baker.make(models.Person, _using=settings.EXTRA_DB)
-        related = baker.make(
-            models.RelatedNamesModel,
-            one_to_one=placeholder,
-            _using=settings.EXTRA_DB,
-        )
-        person = baker.make(
-            models.Person, one_related=related, _using=settings.EXTRA_DB
-        )
-        related.refresh_from_db(using=settings.EXTRA_DB)
-        assert related.one_to_one == person
-        assert (
-            models.RelatedNamesModel.objects.using(settings.EXTRA_DB)
-            .filter(one_to_one=person)
-            .exists()
-        )
 
 
 class TestBakerAutomaticallyRefreshFromDB:

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -18,7 +18,9 @@ from model_bakery.exceptions import (
     AmbiguousModelName,
     InvalidQuantityException,
     ModelNotFound,
+    RecipeIteratorEmpty,
 )
+from model_bakery.recipe import Recipe, foreign_key
 from model_bakery.timezone import tz_aware
 from tests.generic import baker_recipes, models
 from tests.generic.forms import DummyGenericIPAddressFieldForm
@@ -736,6 +738,176 @@ class TestBakerCreatesAssociatedModels(TestCase):
         related_1, related_2 = obj.bazs.all()
         assert related_1.name == "custom name"
         assert related_2.name == "custom name"
+
+
+class TestReverseOneToOne:
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("bulk_create", [False, True])
+    def test_iterator_is_persisted(self, bulk_create):
+        related = baker.make(models.RelatedNamesModel, _quantity=2)
+
+        people = baker.make(
+            models.Person,
+            one_related=iter(related),
+            _quantity=2,
+            _bulk_create=bulk_create,
+        )
+
+        for person, relation in zip(people, related, strict=True):
+            assert person.one_related is relation
+            relation.refresh_from_db()
+            person.refresh_from_db()
+            assert relation.one_to_one == person
+            assert person.one_related == relation
+
+    @pytest.mark.django_db
+    def test_bulk_create_resolves_callable_once(self):
+        related = baker.make(models.RelatedNamesModel)
+        values = iter([related])
+
+        person = baker.make(
+            models.Person, one_related=lambda: next(values), _bulk_create=True
+        )
+
+        related.refresh_from_db()
+        assert related.one_to_one == person
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("saved", [False, True])
+    def test_bulk_create_persists_related_object(self, saved):
+        factory = baker.make if saved else baker.prepare
+        related = factory(models.RelatedNamesModel)
+
+        person = baker.make(models.Person, one_related=related, _bulk_create=True)
+
+        related.refresh_from_db()
+        person.refresh_from_db()
+        assert related.one_to_one == person
+        assert person.one_related == related
+        assert models.Person.objects.filter(pk=related.foreign_key_id).exists()
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("bulk_create", [False, True])
+    def test_full_clean_rolls_back_invalid_reverse_object(self, bulk_create):
+        details = baker.prepare(models.ProfileDetails, name="")
+
+        with pytest.raises(ValidationError) as exc:
+            baker.make(
+                models.Profile,
+                details=details,
+                _bulk_create=bulk_create,
+                _full_clean=True,
+            )
+
+        assert "name" in exc.value.message_dict
+        assert not models.Profile.objects.exists()
+        assert not models.User.objects.exists()
+        assert not models.ProfileDetails.objects.exists()
+
+    @pytest.mark.django_db
+    def test_full_clean_validates_unsaved_reverse_dependencies(self):
+        details = baker.prepare(
+            models.ProfileDetails, user__profile__email="not-an-email"
+        )
+
+        with pytest.raises(ValidationError) as exc:
+            baker.make(
+                models.Profile, details=details, _bulk_create=True, _full_clean=True
+            )
+
+        assert "email" in exc.value.message_dict
+        assert not models.Profile.objects.exists()
+        assert not models.User.objects.exists()
+        assert not models.ProfileDetails.objects.exists()
+
+    @pytest.mark.django_db
+    def test_full_clean_rolls_back_reverse_save_failure(self):
+        details = baker.prepare(models.ProfileDetails)
+
+        with (
+            patch.object(details, "save", side_effect=RuntimeError("save failed")),
+            pytest.raises(RuntimeError, match="save failed"),
+        ):
+            baker.make(
+                models.Profile, details=details, _bulk_create=True, _full_clean=True
+            )
+
+        assert not models.Profile.objects.exists()
+        assert not models.User.objects.exists()
+        assert not models.ProfileDetails.objects.exists()
+
+    @pytest.mark.django_db
+    def test_full_clean_does_not_validate_saved_reverse_object(self):
+        details = baker.make(models.ProfileDetails, name="")
+
+        profile = baker.make(
+            models.Profile, details=details, _bulk_create=True, _full_clean=True
+        )
+
+        details.refresh_from_db()
+        assert details.profile == profile
+        assert details.name == ""
+
+    @pytest.mark.django_db(databases=["default", settings.EXTRA_DB])
+    def test_full_clean_saves_reverse_dependencies_on_selected_database(self):
+        details = baker.prepare(
+            models.ProfileDetails,
+            user__profile__email="valid@example.com",
+            _using=settings.EXTRA_DB,
+        )
+
+        profile = baker.make(
+            models.Profile,
+            details=details,
+            _bulk_create=True,
+            _full_clean=True,
+            _using=settings.EXTRA_DB,
+        )
+
+        details.refresh_from_db(using=settings.EXTRA_DB)
+        assert details.profile == profile
+        assert details.user.profile.email == "valid@example.com"
+        assert models.Profile.objects.using(settings.EXTRA_DB).count() == 2
+        assert models.User.objects.using(settings.EXTRA_DB).count() == 1
+        assert not models.Profile.objects.exists()
+        assert not models.User.objects.exists()
+        assert not models.ProfileDetails.objects.exists()
+
+    @pytest.mark.django_db
+    def test_bulk_create_recipe_with_quantity(self):
+        recipe = Recipe(
+            models.Person,
+            one_related=foreign_key(Recipe(models.RelatedNamesModel), one_to_one=True),
+        )
+
+        people = recipe.make(_quantity=2, _bulk_create=True)
+
+        for person in people:
+            person.refresh_from_db()
+            assert person.one_related.one_to_one == person
+        assert people[0].one_related.pk != people[1].one_related.pk
+
+    def test_prepare_preserves_iterator_relations_without_queries(self):
+        related = [models.RelatedNamesModel(), models.RelatedNamesModel()]
+
+        people = baker.prepare(models.Person, one_related=iter(related), _quantity=2)
+
+        for person, relation in zip(people, related, strict=True):
+            assert person.pk is None
+            assert relation.pk is None
+            assert person.one_related is relation
+            assert relation.one_to_one is person
+
+    def test_empty_iterator_raises_recipe_error(self):
+        with pytest.raises(RecipeIteratorEmpty, match="one_related iterator is empty"):
+            baker.prepare(models.Person, one_related=iter(()))
+
+    @pytest.mark.django_db
+    def test_bulk_create_accepts_absent_relation(self):
+        person = baker.make(models.Person, one_related=None, _bulk_create=True)
+
+        person.refresh_from_db()
+        assert not models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
 
 
 class TestHandlingUnsupportedModels:

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -683,6 +683,24 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert person.fk_related.get().name == "Bar"
 
     @pytest.mark.django_db
+    def test_reverse_one_to_one_is_persisted(self):
+        """Regression test for issue #473.
+
+        Reverse OneToOne relations passed as kwargs must be saved to the DB,
+        not just exist in memory on the created instance.
+        """
+        # RelatedNamesModel.one_to_one = OneToOneField(Person, related_name="one_related")
+        # Person.one_related is the reverse accessor — this is the bug scenario.
+        placeholder = baker.make(models.Person)
+        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
+
+        person = baker.make(models.Person, one_related=related)
+
+        related.refresh_from_db()
+        assert related.one_to_one == person
+        assert models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
+
+    @pytest.mark.django_db
     def test_field_lookup_for_related_field_does_not_work_with_prepare(self):
         person = baker.prepare(
             models.Person,
@@ -1251,6 +1269,25 @@ class TestBakerSupportsMultiDatabase(TestCase):
         assert not models.School.objects.exists()
         assert not models.SchoolEnrollment.objects.exists()
         assert not models.Person.objects.exists()
+
+    def test_reverse_one_to_one_respects_using_kwarg(self):
+        """Reverse OneToOne handler must save related object to the correct DB."""
+        placeholder = baker.make(models.Person, _using=settings.EXTRA_DB)
+        related = baker.make(
+            models.RelatedNamesModel,
+            one_to_one=placeholder,
+            _using=settings.EXTRA_DB,
+        )
+        person = baker.make(
+            models.Person, one_related=related, _using=settings.EXTRA_DB
+        )
+        related.refresh_from_db(using=settings.EXTRA_DB)
+        assert related.one_to_one == person
+        assert (
+            models.RelatedNamesModel.objects.using(settings.EXTRA_DB)
+            .filter(one_to_one=person)
+            .exists()
+        )
 
 
 class TestBakerAutomaticallyRefreshFromDB:

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -699,9 +699,7 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
 
     def test_prepare_reverse_one_to_one_is_connected_in_memory(self):
-        """Reverse OneToOne relations passed to prepare() must wire both sides
-        in memory without persisting either object.
-        """
+        """Reverse OneToOne relations passed to prepare() must wire both sides in memory without persisting either object."""
         placeholder = baker.make(models.Person)
         related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -689,8 +689,6 @@ class TestBakerCreatesAssociatedModels(TestCase):
         Reverse OneToOne relations passed as kwargs must be saved to the DB,
         not just exist in memory on the created instance.
         """
-        # RelatedNamesModel.one_to_one = OneToOneField(Person, related_name="one_related")
-        # Person.one_related is the reverse accessor — this is the bug scenario.
         placeholder = baker.make(models.Person)
         related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
 

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -829,9 +829,15 @@ class TestClassifyAttrs(TestCase):
         b = baker.Baker(models.Person)
         attrs = {"name": "foo"}
         with self.assertNumQueries(0):
-            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+            (
+                one_to_many,
+                reverse_one_to_one,
+                auto_now,
+                gfks,
+            ) = b._classify_attrs(attrs)
         assert attrs == {"name": "foo"}
         assert one_to_many == {}
+        assert reverse_one_to_one == {}
         assert auto_now == {}
         assert gfks == {}
 
@@ -840,17 +846,30 @@ class TestClassifyAttrs(TestCase):
         sentinel = [object()]
         attrs = {"name": "foo", "fk_related": sentinel}
         with self.assertNumQueries(0):
-            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+            (
+                one_to_many,
+                reverse_one_to_one,
+                auto_now,
+                gfks,
+            ) = b._classify_attrs(attrs)
         # reverse one-to-many entries are removed from attrs (applied post-save)
         assert "fk_related" not in attrs
         assert one_to_many == {"fk_related": sentinel}
+        assert reverse_one_to_one == {}
+        assert auto_now == {}
+        assert gfks == {}
 
     def test_auto_now_is_copied_not_popped(self):
         b = baker.Baker(models.ModelWithAutoNowFields)
         now = datetime.datetime(2023, 1, 1)
         attrs = {"sent_date": now, "created": now, "updated": now}
         with self.assertNumQueries(0):
-            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+            (
+                one_to_many,
+                reverse_one_to_one,
+                auto_now,
+                gfks,
+            ) = b._classify_attrs(attrs)
         # auto_now/auto_now_add values are copied out for the post-save UPDATE
         # but left on attrs for the constructor; plain DateTimeFields are not.
         assert auto_now == {"created": now, "updated": now}
@@ -864,7 +883,12 @@ class TestClassifyAttrs(TestCase):
         sentinel = object()
         attrs = {"content_object": sentinel}
         with self.assertNumQueries(0):
-            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+            (
+                one_to_many,
+                reverse_one_to_one,
+                auto_now,
+                gfks,
+            ) = b._classify_attrs(attrs)
         assert "content_object" not in attrs
         assert gfks["content_object"]["value"] is sentinel
         assert gfks["content_object"]["content_type_field"] == "content_type"

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -698,6 +698,19 @@ class TestBakerCreatesAssociatedModels(TestCase):
         assert related.one_to_one == person
         assert models.RelatedNamesModel.objects.filter(one_to_one=person).exists()
 
+    def test_prepare_reverse_one_to_one_is_connected_in_memory(self):
+        """Reverse OneToOne relations passed to prepare() must wire both sides
+        in memory without persisting either object.
+        """
+        placeholder = baker.make(models.Person)
+        related = baker.make(models.RelatedNamesModel, one_to_one=placeholder)
+
+        person = baker.prepare(models.Person, one_related=related)
+
+        assert person.pk is None
+        assert person.one_related == related
+        assert related.one_to_one == person
+
     @pytest.mark.django_db
     def test_field_lookup_for_related_field_does_not_work_with_prepare(self):
         person = baker.prepare(


### PR DESCRIPTION
Fixes #473

When a reverse OneToOneField accessor was passed as a kwarg (e.g. `baker.make(User, person=some_person)`), the relationship existed in memory but was never persisted — the FK on the related object was never set and never saved. Querying from the DB after the fact found nothing.

Root cause: `Baker.instance()` only detected `ForeignRelatedObjectsDescriptor` (reverse FK). Reverse OneToOne uses `ReverseOneToOneDescriptor`, which was not handled. Django's `__init__` silently wrote it into `instance.__dict__` without ever updating the related object.

Fix: detect `ReverseOneToOneDescriptor` in `instance()`, extract those attrs, and handle them in a new `_handle_reverse_one_to_one()` method that sets the FK on the related object and saves it — consistent with how `_handle_one_to_many()` works for reverse FK relations.

## Changes
- `model_bakery/baker.py` — new `ReverseOneToOneDescriptor` import; detection added to `instance()` loop; new `_handle_reverse_one_to_one()` method
- `tests/test_baker.py` — regression test in `TestBakerCreatesAssociatedModels` verifying DB persistence via `refresh_from_db()`
- `CHANGELOG.md` — entry under Changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional full validation support for objects created or prepared through `make()`, `prepare()`, and bulk creation.
* **Bug Fixes**
  * Fixed reverse One-to-One relationships not being persisted when provided to `baker.make()`, including iterator, callable, and bulk-creation scenarios.
  * Improved validation and rollback behavior for related objects.
* **Tests**
  * Added coverage for reverse One-to-One persistence, validation, iterators, callables, and multi-database usage.
* **Documentation**
  * Updated the unreleased changelog with the relationship persistence fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->