### PR TITLE
Speed up `Baker.get_fields()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Cache `Baker.get_fields()` results per model to avoid expensive `get_fields()()` calls on every `baker.make` call.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
-- Cache `Baker.get_fields()` results per model to avoid expensive `get_fields()()` calls on every `baker.make` call.
+- Cache `Baker.get_fields()` results per model to avoid expensive `get_fields()` calls on every `baker.make` call.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
-- Cache `Baker.get_fields()` results per model to avoid expensive `get_fields()` calls on every `baker.make` call.
+- Speed up `Baker.get_fields()` by returning `_meta.fields + _meta.many_to_many` directly instead of filtering `_meta.get_fields()`.
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -433,7 +433,11 @@ class Baker(Generic[M]):
         return self._make(**params)
 
     def get_fields(self) -> tuple[Any, ...]:
-        return (*self.model._meta.fields, *self.model._meta.many_to_many)
+        return (
+            *self.model._meta.fields,
+            *self.model._meta.many_to_many,
+            *self.model._meta.private_fields,
+        )
 
     def _make(  # noqa: C901
         self,

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -347,6 +347,9 @@ class Baker(Generic[M]):
     # rebuilding the model cache for every make_* or prepare_* call.
     finder = ModelFinder()
 
+    # Cache for get_fields() results per model. Uses id()-based comparison
+    _fields_cache: dict[type[Model], set[Any]] = {}
+
     @classmethod
     def seed(cls, seed: int | float | str | bytes | bytearray | None) -> None:
         random_gen.baker_random.seed(seed)
@@ -433,9 +436,13 @@ class Baker(Generic[M]):
         return self._make(**params)
 
     def get_fields(self) -> set[Any]:
-        return set(self.model._meta.get_fields()) - set(
-            self.model._meta.related_objects
-        )
+        model = self.model
+        if model not in self._fields_cache:
+            related_ids = {id(f) for f in model._meta.related_objects}
+            self._fields_cache[model] = {
+                f for f in model._meta.get_fields() if id(f) not in related_ids
+            }
+        return self._fields_cache[model]
 
     def _make(  # noqa: C901
         self,

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -347,9 +347,6 @@ class Baker(Generic[M]):
     # rebuilding the model cache for every make_* or prepare_* call.
     finder = ModelFinder()
 
-    # Cache for get_fields() results per model. Uses id()-based comparison
-    _fields_cache: dict[type[Model], set[Any]] = {}
-
     @classmethod
     def seed(cls, seed: int | float | str | bytes | bytearray | None) -> None:
         random_gen.baker_random.seed(seed)
@@ -435,14 +432,8 @@ class Baker(Generic[M]):
         params.update(attrs)
         return self._make(**params)
 
-    def get_fields(self) -> set[Any]:
-        model = self.model
-        if model not in self._fields_cache:
-            related_ids = {id(f) for f in model._meta.related_objects}
-            self._fields_cache[model] = {
-                f for f in model._meta.get_fields() if id(f) not in related_ids
-            }
-        return self._fields_cache[model]
+    def get_fields(self) -> tuple[Any, ...]:
+        return (*self.model._meta.fields, *self.model._meta.many_to_many)
 
     def _make(  # noqa: C901
         self,

--- a/tests/generic/fields.py
+++ b/tests/generic/fields.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models.fields.mixins import FieldCacheMixin
 
 
 class CustomFieldWithGenerator(models.TextField):
@@ -23,3 +24,34 @@ class FakeListField(models.TextField):
 
 class CustomForeignKey(models.ForeignKey):
     pass
+
+
+class PrivateMarkerField(FieldCacheMixin):
+    """Virtual field that lives only in ``_meta.private_fields``.
+
+    Mirrors how ``GenericForeignKey`` attaches to a model — no DB column, no
+    entry in ``_meta.fields`` — but without the contenttypes dependency. Used
+    to exercise code paths that must surface private fields regardless of
+    whether contenttypes is installed.
+    """
+
+    auto_created = False
+    concrete = False
+    editable = False
+    hidden = False
+    is_relation = True
+    many_to_many = False
+    many_to_one = True
+    one_to_many = False
+    one_to_one = False
+    related_model = None
+    remote_field = None
+
+    def __str__(self):
+        return f"{self.model._meta.label}.{self.name}"
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        self.name = name
+        self.attname = name
+        self.model = cls
+        cls._meta.add_field(self, private=True)

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -21,6 +21,7 @@ from .fields import (
     CustomFieldWithoutGenerator,
     CustomForeignKey,
     FakeListField,
+    PrivateMarkerField,
 )
 
 # check whether PIL is installed
@@ -65,6 +66,11 @@ TEST_TIME = datetime.datetime(2014, 7, 21, 15, 39, 58, 457698)
 
 class ModelWithImpostorField(models.Model):
     pass
+
+
+class ModelWithPrivateField(models.Model):
+    name = models.CharField(max_length=32)
+    marker = PrivateMarkerField()
 
 
 class Profile(models.Model):

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1535,3 +1535,41 @@ class TestReverseRelations:
         baker_instance = baker.Baker(models.Person)
         with pytest.raises(AttributeError, match="has_default"):
             baker_instance.generate_value(reverse_rel)
+
+
+class TestGetFieldsCaching:
+    """Tests for Baker.get_fields() caching and id()-based filtering."""
+
+    def test_get_fields_excludes_related_objects(self):
+        """get_fields() must not include reverse relations."""
+        baker_instance = baker.Baker(models.Person)
+        fields = baker_instance.get_fields()
+        related_objects = set(models.Person._meta.related_objects)
+        assert not fields & related_objects
+
+    def test_get_fields_result_is_cached(self):
+        """Calling get_fields() twice for the same model returns the same object."""
+        baker.Baker._fields_cache.pop(models.Person, None)
+        b1 = baker.Baker(models.Person)
+        b2 = baker.Baker(models.Person)
+        result1 = b1.get_fields()
+        result2 = b2.get_fields()
+        assert result1 is result2
+
+    def test_get_fields_different_models_cached_separately(self):
+        """Different models get their own cache entries."""
+        baker.Baker._fields_cache.pop(models.Person, None)
+        baker.Baker._fields_cache.pop(models.Profile, None)
+        person_fields = baker.Baker(models.Person).get_fields()
+        profile_fields = baker.Baker(models.Profile).get_fields()
+        assert person_fields is not profile_fields
+
+    def test_get_fields_includes_all_non_reverse_fields(self):
+        """get_fields() includes every field from _meta.get_fields() except related_objects."""
+        baker.Baker._fields_cache.pop(models.Person, None)
+        all_fields = set(models.Person._meta.get_fields())
+        related = set(models.Person._meta.related_objects)
+        expected = all_fields - related
+
+        result = baker.Baker(models.Person).get_fields()
+        assert result == expected

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1555,3 +1555,8 @@ class TestGetFields:
             *models.Person._meta.many_to_many,
         )
         assert result == expected
+
+    def test_get_fields_includes_private_fields(self):
+        """get_fields() includes private fields (e.g. GFK fields)."""
+        fields = baker.Baker(models.ModelWithPrivateField).get_fields()
+        assert "marker" in {f.name for f in fields}

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1537,39 +1537,21 @@ class TestReverseRelations:
             baker_instance.generate_value(reverse_rel)
 
 
-class TestGetFieldsCaching:
-    """Tests for Baker.get_fields() caching and id()-based filtering."""
+class TestGetFields:
+    """Tests for Baker.get_fields()."""
 
     def test_get_fields_excludes_related_objects(self):
         """get_fields() must not include reverse relations."""
         baker_instance = baker.Baker(models.Person)
-        fields = baker_instance.get_fields()
+        fields = set(baker_instance.get_fields())
         related_objects = set(models.Person._meta.related_objects)
         assert not fields & related_objects
 
-    def test_get_fields_result_is_cached(self):
-        """Calling get_fields() twice for the same model returns the same object."""
-        baker.Baker._fields_cache.pop(models.Person, None)
-        b1 = baker.Baker(models.Person)
-        b2 = baker.Baker(models.Person)
-        result1 = b1.get_fields()
-        result2 = b2.get_fields()
-        assert result1 is result2
-
-    def test_get_fields_different_models_cached_separately(self):
-        """Different models get their own cache entries."""
-        baker.Baker._fields_cache.pop(models.Person, None)
-        baker.Baker._fields_cache.pop(models.Profile, None)
-        person_fields = baker.Baker(models.Person).get_fields()
-        profile_fields = baker.Baker(models.Profile).get_fields()
-        assert person_fields is not profile_fields
-
-    def test_get_fields_includes_all_non_reverse_fields(self):
-        """get_fields() includes every field from _meta.get_fields() except related_objects."""
-        baker.Baker._fields_cache.pop(models.Person, None)
-        all_fields = set(models.Person._meta.get_fields())
-        related = set(models.Person._meta.related_objects)
-        expected = all_fields - related
-
+    def test_get_fields_returns_concrete_and_m2m_fields(self):
+        """get_fields() returns concrete fields plus many-to-many fields."""
         result = baker.Baker(models.Person).get_fields()
+        expected = (
+            *models.Person._meta.fields,
+            *models.Person._meta.many_to_many,
+        )
         assert result == expected


### PR DESCRIPTION
**Describe the change**
This change caches `get_fields()` call that can be expensive on larger models. This change almost halved our test execution time:

Before:
```
16082 passed, 1099 subtests passed in 534.87s (0:08:54)
```

After:
```
16082 passed, 1099 subtests passed in 280.93s (0:04:40)
``` 

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Field lookup now returns an ordered sequence of concrete, many-to-many, and private fields (excluding reverse relations), improving speed and stability.

* **Tests**
  * Added tests to verify field selection order, exclusion of reverse relations, and presence of private fields.

* **Documentation**
  * Changelog updated to reflect the performance and return-format change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->