### PR TITLE
Fix bulk_create _using propagation for related objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - When using `baker.make(..., _bulk_create=True, _full_clean=True)`, the operation is wrapped in a transaction to ensure atomic rollback if validation fails
 - Use the requested `_using` database consistently for generated related objects in `baker.make(..., _bulk_create=True)`
+- Preserve correct parent-to-FK associations in `baker.make(..., _bulk_create=True)` when related objects mix saved and unsaved instances
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - When using `baker.make(..., _bulk_create=True, _full_clean=True)`, the operation is wrapped in a transaction to ensure atomic rollback if validation fails
+- Use the requested `_using` database consistently for generated related objects in `baker.make(..., _bulk_create=True)`
 
 ### Removed
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -593,6 +593,8 @@ class Baker(Generic[M]):
                 }
 
         instance = self.model(**attrs)
+        if using := _save_kwargs.get("using"):
+            instance._state.db = using
 
         self._handle_generic_foreign_keys(
             instance, generic_foreign_keys, commit=_commit
@@ -981,9 +983,12 @@ def _save_related_objs(model, objects, _using=None, _full_clean=False) -> None:
             _save_related_objs(
                 fk.related_model,
                 fk_objects,
+                _using=_using,
                 _full_clean=_full_clean,
             )
             for i, fk_obj in enumerate(fk_objects):
+                if _using:
+                    fk_obj._state.db = _using
                 if _full_clean:
                     fk_obj.full_clean()
                 fk_obj.save(**_save_kwargs)

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -973,26 +973,27 @@ def _save_related_objs(model, objects, _using=None, _full_clean=False) -> None:
     ]
 
     for fk in fk_fields:
-        fk_objects = []
+        fk_targets = []
         for obj in objects:
             fk_obj = getattr(obj, fk.name, None)
             if fk_obj and not fk_obj.pk:
-                fk_objects.append(fk_obj)
+                fk_targets.append((obj, fk_obj))
 
-        if fk_objects:
+        if fk_targets:
+            fk_objects = [fk_obj for _, fk_obj in fk_targets]
             _save_related_objs(
                 fk.related_model,
                 fk_objects,
                 _using=_using,
                 _full_clean=_full_clean,
             )
-            for i, fk_obj in enumerate(fk_objects):
+            for obj, fk_obj in fk_targets:
                 if _using:
                     fk_obj._state.db = _using
                 if _full_clean:
                     fk_obj.full_clean()
                 fk_obj.save(**_save_kwargs)
-                setattr(objects[i], fk.name, fk_obj)
+                setattr(obj, fk.name, fk_obj)
 
 
 def bulk_create(  # noqa: C901

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.models import Manager, ManyToOneRel
 from django.db.models.signals import m2m_changed
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 import pytest
 
@@ -1066,34 +1066,29 @@ class TestBakerSupportsMultiDatabase(TestCase):
     def test_related_fk_database_specified_via_using_kwarg_combined_with_bulk_create(
         self,
     ):
-        # A custom router must be used when using bulk create and saving
-        # related objects in a multi-database setting.
-        class AllowRelationRouter:
-            """Custom router that allows saving of relations."""
-
-            def allow_relation(self, obj1, obj2, **hints):
-                """Allow all relations."""
-                return True
-
-        with override_settings(DATABASE_ROUTERS=[AllowRelationRouter()]):
-            baker.make(
-                models.PaymentBill,
-                _quantity=5,
-                _bulk_create=True,
-                _using=settings.EXTRA_DB,
-            )
+        baker.make(
+            models.PaymentBill,
+            _quantity=5,
+            _bulk_create=True,
+            _using=settings.EXTRA_DB,
+        )
 
         assert models.PaymentBill.objects.all().using(settings.EXTRA_DB).count() == 5
         assert models.User.objects.all().using(settings.EXTRA_DB).count() == 5
 
-        # Default router will not be able to save the related objects
-        with pytest.raises(ValueError):
-            baker.make(
-                models.PaymentBill,
-                _quantity=5,
-                _bulk_create=True,
-                _using=settings.EXTRA_DB,
-            )
+    def test_bulk_create_with_using_keeps_nested_fk_on_same_db(self):
+        baker.make(
+            models.PaymentBill,
+            user__profile__email="valid@example.com",
+            _quantity=1,
+            _bulk_create=True,
+            _using=settings.EXTRA_DB,
+        )
+
+        assert models.PaymentBill.objects.using(settings.EXTRA_DB).count() == 1
+        assert models.User.objects.using(settings.EXTRA_DB).count() == 1
+        assert models.Profile.objects.using(settings.EXTRA_DB).count() == 1
+        assert models.Profile.objects.using("default").count() == 0
 
     def test_allow_recipe_to_specify_database_via_using(self):
         dog = baker.make_recipe("generic.homeless_dog", _using=settings.EXTRA_DB)

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1075,6 +1075,25 @@ class TestBakerSupportsMultiDatabase(TestCase):
 
         assert models.PaymentBill.objects.all().using(settings.EXTRA_DB).count() == 5
         assert models.User.objects.all().using(settings.EXTRA_DB).count() == 5
+        assert models.PaymentBill.objects.using("default").count() == 0
+        assert models.User.objects.using("default").count() == 0
+
+    def test_bulk_create_keeps_mixed_saved_and_unsaved_fks_on_original_objects(self):
+        saved_user = baker.make(models.User, _using=settings.EXTRA_DB)
+        unsaved_user = baker.prepare(models.User, _using=settings.EXTRA_DB)
+
+        bills = baker.make(
+            models.PaymentBill,
+            user=iter([saved_user, unsaved_user]),
+            _quantity=2,
+            _bulk_create=True,
+            _using=settings.EXTRA_DB,
+        )
+
+        assert bills[0].user == saved_user
+        assert bills[1].user == unsaved_user
+        assert models.PaymentBill.objects.using(settings.EXTRA_DB).count() == 2
+        assert models.User.objects.using(settings.EXTRA_DB).count() == 2
 
     def test_bulk_create_with_using_keeps_nested_fk_on_same_db(self):
         baker.make(


### PR DESCRIPTION
**Describe the change**
- Ensure `baker.make(..., _bulk_create=True, _using=...)` uses the requested database for generated related objects
- Propagate `_using` recursively when saving nested FK objects during bulk create
- Set unsaved instance DB state before relation handling so Django routers allow same-db relations

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk-create now consistently writes generated related objects to the specified database and preserves correct parent→foreign-key associations when related objects mix saved and unsaved instances, including nested relations.

* **Tests**
  * Added regression tests covering mixed saved/unsaved FK scenarios and nested FK bulk-create behavior across databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->