### PR TITLE
Fix #601: Avoid AttributeError when using `related` with reverse M2M relation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix `related()` with reverse M2M relations raising `AttributeError` ([#601](https://github.com/model-bakers/model_bakery/issues/601))
 - [dev] Modernize tox and CI around `tox-uv`, dependency groups, reusable coverage/docs tox environments, and docs validation in CI
 - When using `baker.make(..., _bulk_create=True, _full_clean=True)`, the operation is wrapped in a transaction to ensure atomic rollback if validation fails
 - Use the requested `_using` database consistently for generated related objects in `baker.make(..., _bulk_create=True)`

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -744,8 +744,10 @@ class Baker(Generic[M]):
             manager = getattr(instance, key)
 
             if callable(values):
-                if isinstance(values, types.MethodType) and isinstance(
-                    values.__self__, related
+                if (
+                    isinstance(values, types.MethodType)
+                    and isinstance(values.__self__, related)
+                    and hasattr(manager, "field")
                 ):
                     fk_field_name = manager.field.name
                     values = values(**{fk_field_name: instance})

--- a/tests/generic/baker_recipes.py
+++ b/tests/generic/baker_recipes.py
@@ -10,6 +10,7 @@ from tests.generic.models import (
     Dog,
     DummyDefaultFieldsModel,
     DummyUniqueIntegerFieldModel,
+    Home,
     LonelyPerson,
     Person,
     School,
@@ -56,12 +57,16 @@ serial_datetime = Recipe(
     default_time_field=seq(TEST_TIME.time(), timedelta(seconds=15), start="xpto"),
 )
 
+home = Recipe(Home)
+
 dog = Recipe(Dog, breed="Pug", owner=foreign_key(person))
 
 homeless_dog = Recipe(
     Dog,
     breed="Pug",
 )
+
+village_dog = Recipe(Dog, home_set=related(home, home, home))
 
 other_dog = Recipe(Dog, breed="Basset", owner=foreign_key("person"))
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -536,7 +536,7 @@ class TestM2MField:
 
 
     @pytest.mark.django_db
-    def test_create_related_many_to_many(self):
+    def test_create_reverse_many_to_many_with_related(self):
         dog = baker.make_recipe("tests.generic.village_dog")
         assert len(dog.home_set.all()) == 3
         for home in dog.home_set.all():

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -534,7 +534,6 @@ class TestM2MField:
         friend = dog.friends_with.all()[0]
         assert len(friend.friends_with.all()) == 2
 
-
     @pytest.mark.django_db
     def test_create_reverse_many_to_many_with_related(self):
         dog = baker.make_recipe("tests.generic.village_dog")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -535,6 +535,15 @@ class TestM2MField:
         assert len(friend.friends_with.all()) == 2
 
 
+    @pytest.mark.django_db
+    def test_create_related_many_to_many(self):
+        dog = baker.make_recipe("tests.generic.village_dog")
+        assert len(dog.home_set.all()) == 3
+        for home in dog.home_set.all():
+            assert home.dogs.count() == 1
+            assert home.dogs.first() == dog
+
+
 class TestSequences:
     @pytest.mark.django_db
     def test_increment_for_strings(self):


### PR DESCRIPTION
**Describe the change**
This PR avoids the AttributeError in #601 by checking beforehand whether the manager object there has the attribute "fields". It includes and passes the test created by @ento 

**PR Checklist**
- [x] Change is covered with tests
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

* **Bug Fixes**
  * Fixed `related()` handling for reverse many-to-many relations to prevent an `AttributeError`, with more robust logic when reverse manager metadata is missing.

* **Tests**
  * Added coverage for creating reverse many-to-many data using related recipe fixtures, verifying expected counts and that linked objects reference the originals.

* **Documentation / Chores**
  * Updated the Unreleased changelog to note the reverse M2M `related()` fix (issue `#601`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->