### PR TITLE
Extract pure attr-classification into Baker._classify_attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/model-bakers/model_bakery/tree/main)
 
+### Changed
+
+- [dev] Extract the attr-partitioning logic out of `Baker.instance()` into a pure, database-free `Baker._classify_attrs()` helper, with direct unit tests asserting it runs zero queries
+
 ## [1.24.0](https://pypi.org/project/model-bakery/1.24.0/)
 
 ### Added

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -560,14 +560,21 @@ class Baker(Generic[M]):
             return []
         return self.generate_value(field)
 
-    def instance(
-        self,
-        attrs: dict[str, Any],
-        _commit,
-        _save_kwargs,
-        _from_manager,
-        _full_clean=False,
-    ) -> M:
+    def _classify_attrs(
+        self, attrs: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Partition ``attrs`` into reverse-FK, auto-now, and GFK groups.
+
+        Pure logic, no database access: inspects the model's field descriptors
+        and routes entries that cannot be passed straight to the model
+        constructor. Reverse one-to-many and generic-foreign-key entries are
+        *popped* out of ``attrs`` (they are applied after the instance exists);
+        auto-now entries are *copied* out (the value is also kept on ``attrs``
+        and re-applied via an UPDATE after save, since Django overwrites
+        ``auto_now``/``auto_now_add`` fields on save).
+
+        Returns ``(one_to_many_keys, auto_now_keys, generic_foreign_keys)``.
+        """
         one_to_many_keys = {}
         auto_now_keys = {}
         generic_foreign_keys = {}
@@ -591,6 +598,20 @@ class Baker(Generic[M]):
                     "object_id_field": field.fk_field,
                     "for_concrete_model": field.for_concrete_model,
                 }
+
+        return one_to_many_keys, auto_now_keys, generic_foreign_keys
+
+    def instance(
+        self,
+        attrs: dict[str, Any],
+        _commit,
+        _save_kwargs,
+        _from_manager,
+        _full_clean=False,
+    ) -> M:
+        one_to_many_keys, auto_now_keys, generic_foreign_keys = self._classify_attrs(
+            attrs
+        )
 
         instance = self.model(**attrs)
         if using := _save_kwargs.get("using"):

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -794,6 +794,59 @@ class TestHandlingContentTypeFieldNoQueries:
         assert isinstance(dummy.content_type, ContentType)
 
 
+class TestClassifyAttrs(TestCase):
+    """``Baker._classify_attrs`` partitions attrs without touching the database.
+
+    It inspects the model's field descriptors to route reverse-FK, auto-now and
+    GFK entries, and is asserted DB-free via ``assertNumQueries(0)``.
+    """
+
+    def test_plain_fields_are_left_untouched(self):
+        b = baker.Baker(models.Person)
+        attrs = {"name": "foo"}
+        with self.assertNumQueries(0):
+            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+        assert attrs == {"name": "foo"}
+        assert one_to_many == {}
+        assert auto_now == {}
+        assert gfks == {}
+
+    def test_reverse_fk_is_popped(self):
+        b = baker.Baker(models.Person)
+        sentinel = [object()]
+        attrs = {"name": "foo", "fk_related": sentinel}
+        with self.assertNumQueries(0):
+            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+        # reverse one-to-many entries are removed from attrs (applied post-save)
+        assert "fk_related" not in attrs
+        assert one_to_many == {"fk_related": sentinel}
+
+    def test_auto_now_is_copied_not_popped(self):
+        b = baker.Baker(models.ModelWithAutoNowFields)
+        now = datetime.datetime(2023, 1, 1)
+        attrs = {"sent_date": now, "created": now, "updated": now}
+        with self.assertNumQueries(0):
+            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+        # auto_now/auto_now_add values are copied out for the post-save UPDATE
+        # but left on attrs for the constructor; plain DateTimeFields are not.
+        assert auto_now == {"created": now, "updated": now}
+        assert attrs == {"sent_date": now, "created": now, "updated": now}
+
+    @pytest.mark.skipif(
+        not BAKER_CONTENTTYPES, reason="Django contenttypes is not installed"
+    )
+    def test_generic_foreign_key_is_popped(self):
+        b = baker.Baker(models.DummyGenericForeignKeyModel)
+        sentinel = object()
+        attrs = {"content_object": sentinel}
+        with self.assertNumQueries(0):
+            one_to_many, auto_now, gfks = b._classify_attrs(attrs)
+        assert "content_object" not in attrs
+        assert gfks["content_object"]["value"] is sentinel
+        assert gfks["content_object"]["content_type_field"] == "content_type"
+        assert gfks["content_object"]["object_id_field"] == "object_id"
+
+
 class TestSkipNullsTestCase:
     @pytest.mark.django_db
     def test_skip_null(self):


### PR DESCRIPTION
Follow up proposal from https://github.com/model-bakers/model_bakery/issues/542#issuecomment-4801968515 I ended up not tackling the C901 issue. It's a more ambitious change and I could try it in the future.

`Baker.instance()` mixed two concerns: a database-free pass that partitions incoming attrs by inspecting the model's field descriptors (reverse one-to-many, auto_now/auto_now_add, and generic foreign keys), and the actual object construction/persistence.

Pull the classification pass into a `_classify_attrs()` helper. It is pure logic with no database access, which makes it directly unit-testable without hitting a DB (the new tests assert this via `assertNumQueries(0)`) and shortens `instance()` to its persistence responsibilities.

The queries assertion is very much a "helps async de-duplication" need. I'd rather just allow this to be explicit about this, but I could remove it.

No behavior change.

Claude Opus 4.8 was used to generate this code and reviewed by me.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed

^ Unsure if this really merits a changelog note. If not, let me know and I'll remove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object creation handling for reverse relations, auto-timestamp fields, and generic foreign keys.
  * Reduced unnecessary database work during attribute processing, helping instance creation stay faster and cleaner.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->