### PR TITLE
Add Django 6.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["5.2", "6.0"]
+        django-version: ["5.2", "6.0", "6.1"]
         exclude:
-          # Django 6.0 supports Python 3.12+
+          # Django 6.x supports Python 3.12+
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -77,18 +81,22 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["5.2", "6.0"]
+        django-version: ["5.2", "6.0", "6.1"]
         variant: ["postgresql", "postgresql-psycopg3"]
         exclude:
-          # Django 6.0 supports Python 3.12+
+          # Django 6.x supports Python 3.12+
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
         include:
           # Latest Python/Django with contenttypes disabled
           - python-version: "3.14"
-            django-version: "6.0"
+            django-version: "6.1"
             variant: "postgresql-no-contenttypes"
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - [dev] Extract the attr-partitioning logic out of `Baker.instance()` into a pure, database-free `Baker._classify_attrs()` helper, with direct unit tests asserting it runs zero queries
+- [dev] Add Django 6.1 support and CI coverage
 
 ## [1.24.0](https://pypi.org/project/model-bakery/1.24.0/)
 

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -565,12 +565,12 @@ class Baker(Generic[M]):
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
         """Partition ``attrs`` into reverse-FK, auto-now, and GFK groups.
 
-        Pure logic, no database access: inspects the model's field descriptors
-        and routes entries that cannot be passed straight to the model
-        constructor. Reverse one-to-many and generic-foreign-key entries are
-        *popped* out of ``attrs`` (they are applied after the instance exists);
-        auto-now entries are *copied* out (the value is also kept on ``attrs``
-        and re-applied via an UPDATE after save, since Django overwrites
+        Pure logic, no database access: normalizes the model's field descriptors
+        to their backing fields and routes entries that cannot be passed straight
+        to the model constructor. Reverse one-to-many and generic-foreign-key
+        entries are *popped* out of ``attrs`` (they are applied after the instance
+        exists); auto-now entries are *copied* out (the value is also kept on
+        ``attrs`` and re-applied via an UPDATE after save, since Django overwrites
         ``auto_now``/``auto_now_add`` fields on save).
 
         Returns ``(one_to_many_keys, auto_now_keys, generic_foreign_keys)``.
@@ -579,21 +579,22 @@ class Baker(Generic[M]):
         auto_now_keys = {}
         generic_foreign_keys = {}
 
-        for k in tuple(attrs.keys()):
-            field = getattr(self.model, k, None)
+        for name in tuple(attrs):
+            descriptor = getattr(self.model, name, None)
 
-            if not field:
+            if descriptor is None:
                 continue
 
-            if isinstance(field, ForeignRelatedObjectsDescriptor):
-                one_to_many_keys[k] = attrs.pop(k)
+            if isinstance(descriptor, ForeignRelatedObjectsDescriptor):
+                one_to_many_keys[name] = attrs.pop(name)
 
-            if hasattr(field, "field") and _is_auto_datetime_field(field.field):
-                auto_now_keys[k] = attrs[k]
+            field = getattr(descriptor, "field", descriptor)
+            if _is_auto_datetime_field(field):
+                auto_now_keys[name] = attrs[name]
 
             if BAKER_CONTENTTYPES and isinstance(field, GenericForeignKey):
-                generic_foreign_keys[k] = {
-                    "value": attrs.pop(k),
+                generic_foreign_keys[name] = {
+                    "value": attrs.pop(name),
                     "content_type_field": field.ct_field,
                     "object_id_field": field.fk_field,
                     "for_concrete_model": field.for_concrete_model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,10 @@ env_list =
     py{310,311,312,313,314}-django52-{sqlite,postgresql,postgresql-psycopg3}
     # Python 3.12+ - Django 6.0
     py{312,313,314}-django60-{sqlite,postgresql,postgresql-psycopg3}
+    # Python 3.12+ - Django 6.1
+    py{312,313,314}-django61-{sqlite,postgresql,postgresql-psycopg3}
     # Latest Python/Django without contenttypes
-    py314-django60-postgresql-no-contenttypes
+    py314-django61-postgresql-no-contenttypes
     docs-build
     coverage-combine
     coverage-report
@@ -30,6 +32,7 @@ setenv =
 deps =
     django52: Django>=5.2,<5.3
     django60: Django>=6.0a1,<6.1
+    django61: Django>=6.1a1,<6.2
     postgresql: psycopg2-binary
     postgresql-psycopg3,postgresql-no-contenttypes: psycopg
 commands =


### PR DESCRIPTION
**Describe the change**
Getting ready for https://docs.djangoproject.com/en/dev/releases/6.1/

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Django 6.1.
  - Added project metadata identifying compatibility with Django 6.1.

- **Tests**
  - Expanded automated testing across Python 3.12–3.14 with Django 6.1.
  - Added SQLite and PostgreSQL coverage, including configurations without content types.
  - Updated compatibility checks for supported Python and Django combinations.

- **Documentation**
  - Added Django 6.1 support to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->