### PR TITLE
Ci deps hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - ruff check --output-format=github .
           - black --check --diff .
           - ty check model_bakery
+          - pre-commit run zizmor --all-files
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [dev] Extract the attr-partitioning logic out of `Baker.instance()` into a pure, database-free `Baker._classify_attrs()` helper, with direct unit tests asserting it runs zero queries
 - [dev] Add Django 6.1 support and CI coverage
+- [dev] Align uv and Dependabot dependency cooldowns and enforce Zizmor in CI
 
 ## [1.24.0](https://pypi.org/project/model-bakery/1.24.0/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["uv_build>=0.9.26,<0.12.0"]
 build-backend = "uv_build"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.build-backend]
 module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "alabaster"
 version = "1.0.0"


### PR DESCRIPTION
**Describe the change**
- Align uv and Dependabot on a 7-day dependency cooldown
- Switch Dependabot to the uv ecosystem
- Run Zizmor as part of CI

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update management with a consistent package ecosystem and a seven-day stabilization window for newer releases.
  * Added automated security workflow checks to help identify issues before changes are integrated.
* **Documentation**
  * Updated the unreleased changelog with the latest dependency-management and security-validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->