### PR TITLE
Preserve reverse OneToOne relation on prepare

### DIFF
--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -281,6 +281,14 @@ class TestBakerPrepareSavingRelatedInstances:
         assert dog.owner is not None
         assert dog.owner.pk is None
 
+    def test_prepare_preserves_reverse_one_to_one(self):
+        related = models.RelatedNamesModel()
+
+        person = baker.prepare(models.Person, one_related=related)
+
+        assert person.one_related is related
+        assert related.one_to_one is person
+
     def test_access_reverse_fk_on_unsaved_instance(self):
         """Reverse FK and M2M access on unsaved instances raises ValueError."""
         dog = baker.prepare(models.Dog)


### PR DESCRIPTION
A small patch hardening our test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to verify that preparing an unsaved person preserves a supplied reverse one-to-one relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->