### PR TITLE
Fix auto_now overrides not being saved on non-default databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix explicit `auto_now`/`auto_now_add` values being written to the wrong database when `_using` is set, and route the follow-up `UPDATE` through `_base_manager` so it also works on models without an `objects` manager or with a filtered default manager
 - [dev] Extract the attr-partitioning logic out of `Baker.instance()` into a pure, database-free `Baker._classify_attrs()` helper, with direct unit tests asserting it runs zero queries
 - [dev] Add Django 6.1 support and CI coverage
 - [dev] Align uv and Dependabot dependency cooldowns, enforce Zizmor in CI, and update pre-commit hooks with Dependabot

--- a/model_bakery/baker.py
+++ b/model_bakery/baker.py
@@ -748,7 +748,11 @@ class Baker(Generic[M]):
             return
 
         # use .update() to force update auto_now fields
-        instance.__class__.objects.filter(pk=instance.pk).update(**attrs)
+        manager = instance.__class__._base_manager
+        db = self._using or instance._state.db
+        if db:
+            manager = manager.using(db)
+        manager.filter(pk=instance.pk).update(**attrs)
 
         # to make the resulting instance has the specified values
         for k, v in attrs.items():

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -545,3 +545,27 @@ class ModelWithAutoNowFields(models.Model):
     sent_date = models.DateTimeField()
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
+
+
+class ExcludeAllManager(models.Manager):
+    """A default manager that filters out every row, like a soft-delete manager."""
+
+    def get_queryset(self):
+        return super().get_queryset().none()
+
+
+class ModelWithAutoNowAndCustomManagerName(models.Model):
+    """`auto_now` model whose only manager is *not* called ``objects``."""
+
+    created = models.DateTimeField(auto_now_add=True)
+
+    entries = models.Manager()
+
+
+class ModelWithAutoNowAndFilteredManager(models.Model):
+    """`auto_now` model whose default manager hides rows from `objects`."""
+
+    created = models.DateTimeField(auto_now_add=True)
+
+    objects = ExcludeAllManager()
+    all_objects = models.Manager()

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1387,10 +1387,6 @@ class TestBakerSeeded:
         assert baker.Baker._global_seed is baker.Baker.SENTINEL
 
 
-def _auto_now_tzinfo():
-    return datetime.timezone.utc if settings.USE_TZ else None
-
-
 class TestAutoNowFields:
     @pytest.mark.django_db
     @pytest.mark.parametrize("use_tz", [False, True])
@@ -1437,7 +1433,7 @@ class TestAutoNowFields:
 
     @pytest.mark.django_db(databases=["default", settings.EXTRA_DB])
     def test_make_with_auto_now_on_non_default_database(self):
-        sent_date = datetime.datetime(2023, 10, 20, 15, 30, tzinfo=_auto_now_tzinfo())
+        sent_date = tz_aware(datetime.datetime(2023, 10, 20, 15, 30))
 
         instance = baker.make(
             models.ModelWithAutoNowFields,
@@ -1458,7 +1454,7 @@ class TestAutoNowFields:
 
     @pytest.mark.django_db
     def test_make_with_auto_now_and_custom_manager_name(self):
-        created = datetime.datetime(2023, 10, 20, 15, 30, tzinfo=_auto_now_tzinfo())
+        created = tz_aware(datetime.datetime(2023, 10, 20, 15, 30))
 
         instance = baker.make(
             models.ModelWithAutoNowAndCustomManagerName,
@@ -1472,7 +1468,7 @@ class TestAutoNowFields:
 
     @pytest.mark.django_db
     def test_make_with_auto_now_and_filtered_default_manager(self):
-        created = datetime.datetime(2023, 10, 20, 15, 30, tzinfo=_auto_now_tzinfo())
+        created = tz_aware(datetime.datetime(2023, 10, 20, 15, 30))
 
         instance = baker.make(
             models.ModelWithAutoNowAndFilteredManager,

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1387,6 +1387,10 @@ class TestBakerSeeded:
         assert baker.Baker._global_seed is baker.Baker.SENTINEL
 
 
+def _auto_now_tzinfo():
+    return datetime.timezone.utc if settings.USE_TZ else None
+
+
 class TestAutoNowFields:
     @pytest.mark.django_db
     @pytest.mark.parametrize("use_tz", [False, True])
@@ -1433,7 +1437,7 @@ class TestAutoNowFields:
 
     @pytest.mark.django_db(databases=["default", settings.EXTRA_DB])
     def test_make_with_auto_now_on_non_default_database(self):
-        sent_date = datetime.datetime(2023, 10, 20, 15, 30)
+        sent_date = datetime.datetime(2023, 10, 20, 15, 30, tzinfo=_auto_now_tzinfo())
 
         instance = baker.make(
             models.ModelWithAutoNowFields,
@@ -1454,7 +1458,7 @@ class TestAutoNowFields:
 
     @pytest.mark.django_db
     def test_make_with_auto_now_and_custom_manager_name(self):
-        created = datetime.datetime(2023, 10, 20, 15, 30)
+        created = datetime.datetime(2023, 10, 20, 15, 30, tzinfo=_auto_now_tzinfo())
 
         instance = baker.make(
             models.ModelWithAutoNowAndCustomManagerName,
@@ -1468,7 +1472,7 @@ class TestAutoNowFields:
 
     @pytest.mark.django_db
     def test_make_with_auto_now_and_filtered_default_manager(self):
-        created = datetime.datetime(2023, 10, 20, 15, 30)
+        created = datetime.datetime(2023, 10, 20, 15, 30, tzinfo=_auto_now_tzinfo())
 
         instance = baker.make(
             models.ModelWithAutoNowAndFilteredManager,

--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1431,6 +1431,55 @@ class TestAutoNowFields:
         assert instance.updated == updated
         assert instance.sent_date == sent_date
 
+    @pytest.mark.django_db(databases=["default", settings.EXTRA_DB])
+    def test_make_with_auto_now_on_non_default_database(self):
+        sent_date = datetime.datetime(2023, 10, 20, 15, 30)
+
+        instance = baker.make(
+            models.ModelWithAutoNowFields,
+            created=sent_date,
+            updated=sent_date,
+            sent_date=sent_date,
+            _using=settings.EXTRA_DB,
+        )
+
+        # Values should be persisted on the requested database, not just set on
+        # the in-memory instance
+        persisted = models.ModelWithAutoNowFields.objects.using(settings.EXTRA_DB).get(
+            pk=instance.pk
+        )
+        assert persisted.created == sent_date
+        assert persisted.updated == sent_date
+        assert persisted.sent_date == sent_date
+
+    @pytest.mark.django_db
+    def test_make_with_auto_now_and_custom_manager_name(self):
+        created = datetime.datetime(2023, 10, 20, 15, 30)
+
+        instance = baker.make(
+            models.ModelWithAutoNowAndCustomManagerName,
+            created=created,
+        )
+
+        persisted = models.ModelWithAutoNowAndCustomManagerName.entries.get(
+            pk=instance.pk
+        )
+        assert persisted.created == created
+
+    @pytest.mark.django_db
+    def test_make_with_auto_now_and_filtered_default_manager(self):
+        created = datetime.datetime(2023, 10, 20, 15, 30)
+
+        instance = baker.make(
+            models.ModelWithAutoNowAndFilteredManager,
+            created=created,
+        )
+
+        persisted = models.ModelWithAutoNowAndFilteredManager.all_objects.get(
+            pk=instance.pk
+        )
+        assert persisted.created == created
+
 
 class TestFieldSpecificIntegerGenerators:
     @pytest.mark.django_db


### PR DESCRIPTION
**Issue**

When you pass an explicit value for an auto_now or auto_now_add field, baker restores it after save() with an UPDATE, because Django overwrites those fields on every save. That UPDATE is currently hardcoded to `instance.__class__.objects` and doesn't take a database.

So this:

```python
baker.make(MyModel, created=some_date, _using="replica")
```

writes the row to `replica`, then runs the UPDATE against `default`, where it matches zero rows.

**Fix**

Use _base_manager on the database the instance was actually saved to. That's what Django uses internally for related-object lookups, and for the same reasons, since it's guaranteed to exist and it doesn't filter.

**Tests**

I've added three regression tests in TestAutoNowFields, one per case. All three fail on main and pass here. I don't
have Postgres/PostGIS set up locally, but nothing here is backend-specific.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed persistence of explicitly provided `auto_now` and `auto_now_add` timestamps when saving to a non-default database.
  * Ensured timestamp values are retained with custom-named or filtered managers.
  * Improved reliability when retrieving saved records through the correct manager and database.
  * Added support for timezone-aware timestamps when timezone support is enabled.

* **Documentation**
  * Added an Unreleased changelog entry describing these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->