### PR TITLE
Use timezone utility in auto_now test

### DIFF
--- a/tests/test_baker.py
+++ b/tests/test_baker.py
@@ -1392,9 +1392,7 @@ class TestAutoNowFields:
     @pytest.mark.parametrize("use_tz", [False, True])
     def test_make_with_auto_now(self, use_tz, settings):
         settings.USE_TZ = use_tz
-        tzinfo = datetime.timezone.utc if use_tz else None
-
-        now = datetime.datetime(2023, 10, 20, 15, 30).replace(tzinfo=tzinfo)
+        now = tz_aware(datetime.datetime(2023, 10, 20, 15, 30))
 
         instance = baker.make(
             models.ModelWithAutoNowFields,


### PR DESCRIPTION
Following up on this comment:
https://github.com/model-bakers/model_bakery/pull/644#discussion_r3904412691

Doing a little cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timezone-aware test setup for automatic timestamp handling.
  * Ensured test datetime construction consistently respects timezone configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->