### PR TITLE
Make URLField and EmailField generators respect max_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Fix reverse `OneToOneField` relations not being persisted to the database when passed as kwargs to `baker.make()`, including iterators and bulk creation ([#473](https://github.com/model-bakers/model_bakery/issues/473))
+- Make the `URLField` and `EmailField` generators respect `max_length`, as `CharField`, `TextField` and `SlugField` already do
 - Fix explicit `auto_now`/`auto_now_add` values being written to the wrong database when `_using` is set, and route the follow-up `UPDATE` through `_base_manager` so it also works on models without an `objects` manager or with a filtered default manager
 - [dev] Extract the attr-partitioning logic out of `Baker.instance()` into a pure, database-free `Baker._classify_attrs()` helper, with direct unit tests asserting it runs zero queries
 - [dev] Add Django 6.1 support and CI coverage

--- a/model_bakery/random_gen.py
+++ b/model_bakery/random_gen.py
@@ -309,12 +309,28 @@ def gen_null_boolean():
     return baker_random.choice((True, False, None))
 
 
-def gen_url() -> str:
-    return f"http://www.{gen_string(30)}.com/"
+_URL_PREFIX = "http://www."
+_URL_SUFFIX = ".com/"
+_EMAIL_DOMAIN = "@example.com"
 
 
-def gen_email() -> str:
-    return f"{gen_string(10)}@example.com"
+def gen_url(max_length: int = MAX_LENGTH) -> str:
+    fixed = len(_URL_PREFIX) + len(_URL_SUFFIX)
+    return (
+        f"{_URL_PREFIX}{gen_string(max(1, min(30, max_length - fixed)))}{_URL_SUFFIX}"
+    )
+
+
+gen_url.required = [_gen_string_get_max_length]  # type: ignore[attr-defined]
+
+
+def gen_email(max_length: int = MAX_LENGTH) -> str:
+    return (
+        f"{gen_string(max(1, min(10, max_length - len(_EMAIL_DOMAIN))))}{_EMAIL_DOMAIN}"
+    )
+
+
+gen_email.required = [_gen_string_get_max_length]  # type: ignore[attr-defined]
 
 
 def gen_ipv6() -> str:

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -111,6 +111,7 @@ class Person(models.Model):
     birth_time = models.TimeField()
     appointment = models.DateTimeField()
     blog = models.URLField()
+    short_blog = models.URLField(max_length=40)
     occupation = models.CharField(max_length=10, choices=OCCUPATION_CHOICES)
     uuid = models.UUIDField(primary_key=False)
     name_hash = models.BinaryField(max_length=16)
@@ -118,6 +119,7 @@ class Person(models.Model):
     days_since_account_creation = models.BigIntegerField()
     duration_of_sleep = models.DurationField()
     email = models.EmailField()
+    short_email = models.EmailField(max_length=20)
     id_document = models.CharField(unique=True, max_length=10)
     data = models.JSONField()
     if django.VERSION >= (5, 0):

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -7,6 +7,8 @@ from tempfile import gettempdir
 import django
 from django.conf import settings
 from django.core.validators import (
+    URLValidator,
+    validate_email,
     validate_ipv4_address,
     validate_ipv6_address,
     validate_ipv46_address,
@@ -279,12 +281,24 @@ class TestURLFieldsFilling:
         assert isinstance(blog_field, fields.URLField)
         assert isinstance(person.blog, str)
 
+    def test_fill_URLField_respects_max_length(self, person):
+        field = models.Person._meta.get_field("short_blog")
+        assert field.max_length == 40
+        assert len(person.short_blog) <= field.max_length
+        URLValidator()(person.short_blog)
+
 
 class TestFillingEmailField:
     def test_filling_EmailField(self, person):
         field = models.Person._meta.get_field("email")
         assert isinstance(field, fields.EmailField)
         assert isinstance(person.email, str)
+
+    def test_filling_EmailField_respects_max_length(self, person):
+        field = models.Person._meta.get_field("short_email")
+        assert field.max_length == 20
+        assert len(person.short_email) <= field.max_length
+        validate_email(person.short_email)
 
 
 class TestFillingIPAddressField:


### PR DESCRIPTION
**Describe the change**

`gen_url()` and `gen_email()` build fixed-size values — 46 and 22 characters — and ignore the field's `max_length`, so `baker.make()` generates something the column cannot hold:

```
field                        max_length   generated
URLField(max_length=40)              40          46   overflow
EmailField(max_length=20)            20          22   overflow
CharField(max_length=12)             12          12   ok
SlugField(max_length=15)             15          15   ok
```

`CharField` and `SlugField` in the same run fit exactly, which is the oracle — and #493 already made `TextField` respect `max_length` for the same reason (validation fails on a too-long value; on PostgreSQL/MySQL the `INSERT` fails outright).

The random part is now sized to fit and capped at its current length, reusing the existing `_gen_string_get_max_length` helper so `max_length=None` keeps working (#408). **Every field that already fits is generated exactly as before**: `URLField` defaults to `max_length=200` and `EmailField` to `254`, and at those sizes the caps of 30 and 10 still bind, so the output is unchanged. Bare `gen_url()` / `gen_email()` calls are unchanged too.

Residual limitation: the templates `http://www.<x>.com/` and `<x>@example.com` have floors of 17 and 13 characters. Below that the value still exceeds `max_length` — but no valid URL or email fits such a field anyway. Raising instead would be easy if you'd rather; I picked the option that changes nothing for fields that work today.

Checked by reverting: with `random_gen.py` back at `main` and the tests kept, exactly the two new tests fail and the other 330 pass. Truncating to `max_length` instead — the obvious shortcut — passes the length assertion but fails `URLValidator`, since it eats the TLD. Fixing only `gen_url` fails the email test, so both halves are pinned. `pytest` is 332 passed / 37 skipped on sqlite, `ruff check`, `ruff format` and `ty check model_bakery` are clean. I did not run the PostgreSQL or PostGIS suites.

**PR Checklist**
- [x] Change is covered with tests
- [x] [CHANGELOG.md](CHANGELOG.md) is updated if needed

AI assistance: this change and its tests were drafted with Claude Opus 5 (`claude-opus-5`). The commands and numbers above were run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated URL and email values now respect configured maximum lengths, including shorter field limits.
  * Generated values continue to meet URL and email validation requirements.

* **Documentation**
  * Clarified minimum lengths for default URL and email generators.
  * Documented that fields with smaller limits require explicit values or a custom generator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->