### PR TITLE
Test Python 3.15 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
   sqlite-tests:
     name: SQLite - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.python-version == '3.15' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         django-version: ["5.2", "6.0", "6.1"]
         exclude:
           # Django 6.x supports Python 3.12+
@@ -78,10 +79,11 @@ jobs:
   postgresql-tests:
     name: PostgreSQL - Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, ${{ matrix.variant }}
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.python-version == '3.15' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         django-version: ["5.2", "6.0", "6.1"]
         variant: ["postgresql", "postgresql-psycopg3"]
         exclude:

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ requires =
     tox-uv
 env_list =
     # Python 3.10+ - Django 5.2
-    py{310,311,312,313,314}-django52-{sqlite,postgresql,postgresql-psycopg3}
+    py{310,311,312,313,314,315}-django52-{sqlite,postgresql,postgresql-psycopg3}
     # Python 3.12+ - Django 6.0
-    py{312,313,314}-django60-{sqlite,postgresql,postgresql-psycopg3}
+    py{312,313,314,315}-django60-{sqlite,postgresql,postgresql-psycopg3}
     # Python 3.12+ - Django 6.1
-    py{312,313,314}-django61-{sqlite,postgresql,postgresql-psycopg3}
+    py{312,313,314,315}-django61-{sqlite,postgresql,postgresql-psycopg3}
     # Latest Python/Django without contenttypes
     py314-django61-postgresql-no-contenttypes
     docs-build


### PR DESCRIPTION
**Describe the change**
Add experimental support for Python 3.15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added Python 3.15 to the supported test matrices across Django, SQLite, and PostgreSQL environments.
  - Python 3.15 CI runs may fail without causing the overall workflow to fail while compatibility is evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->